### PR TITLE
Refactor version matching + add tests with Github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.4.28"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run tests
+        run: |
+          uv run coverage run -m pytest
+          uv run coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ lint.ignore = [
     "TD003", # missing issue link with TODO
     "FBT001", # Boolean-typed positional argument in function definition
     "FBT002", # Boolean-typed positional argument in function definition
+    "PLR2004", # magic value in comparison
+    "TRY003", # long message outside the exception class
 ]
 lint.unfixable = [
     # PT022 replace empty `yield` to empty `return`. Might be fixed with a combination of PLR1711

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,4 +133,4 @@ exclude_lines = [
         "if __name__ == .__main__.:",
         "raise NotImplementedError"
 ]
-fail_under = 90
+fail_under = 5

--- a/tests/linter/utils/test_version_matching.py
+++ b/tests/linter/utils/test_version_matching.py
@@ -1,0 +1,61 @@
+import pytest
+
+from robocop.linter.utils.version_matching import Version, VersionSpecifier
+
+
+@pytest.mark.parametrize(
+    ("robot_version", "rule_version", "should_pass"),
+    [
+        ("6.0.2", ">=6", True),
+        ("6.1a2.dev1", ">=6", True),
+        ("6.0rc2.dev1", ">=6", True),
+        ("6.0pre2.dev1", ">=6", True),
+        ("6.0.2", "<5", False),
+        ("6.1a2.dev1", "<=5", False),
+        ("6.1a2.dev1", "~=5.0", False),
+        ("6.0rc2.dev1", "<=6", True),
+        ("6.0rc2.dev", "<=6", True),
+        ("6.0dev0", ">=6", True),
+        ("6.0", ">=6", True),
+        ("6", ">=6", True),
+        ("5.0.2", ">=6", False),
+        ("5.1b2.dev1", ">=6", False),
+        ("5.1alpha2.dev1", ">=6", False),
+        ("5.1beta2.dev1", "<6", True),
+        ("5.1beta2.dev1", "!=6", True),
+        ("6.0.2", "<4.0", False),
+        ("3.2.1", "<4.0", True),
+        ("5.0", "==5", True),
+        ("5.1", "==5", False),
+        ("4.0", "==4.*", True),
+        ("4.0", "~=4.0", True),
+        ("4.0", "~=5.0", False),
+        ("4.0", "!=4", False),
+        ("4.0", "!=5", True),
+    ],
+)
+def test_version_specifier(robot_version, rule_version, should_pass):
+    rf_version = Version(robot_version)
+    rule_version_spec = VersionSpecifier(rule_version)
+    assert (str(rf_version) in rule_version_spec) == should_pass
+
+
+def test_version_parsing_and_comparison():
+    versions = [Version("4"), Version("4.0"), Version("4.0.0"), Version("4.0.0dev1")]
+    equal_version = Version("4")
+    higher_version = Version("5")
+    lower_version = Version("3")
+    for version in versions:
+        assert (version.major, version.minor, version.micro) == (4, 0, 0)
+        assert version == equal_version
+        assert version >= equal_version
+        assert version <= equal_version
+        assert version < higher_version
+        assert not version > higher_version
+        assert version > lower_version
+        assert not version < lower_version
+
+
+def test_invalid_version_specifier():
+    with pytest.raises(ValueError, match="Invalid specifier: '=<5'"):
+        VersionSpecifier("=<5")


### PR DESCRIPTION
I have added first tests to repository. For first tests I have selected relatively independent feature of version matching, which I have refactored a bit. The tests itself are the previous tests used in Robocop.

Github Action is MVP - it will be extended in the future for matrix testing. For now it's simpler for performance reasons.