### PR TITLE
Add describe rule command

### DIFF
--- a/src/robocop/cli.py
+++ b/src/robocop/cli.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Optional
 
-from rich import print
+from rich.console import Console
 import typer
 
 from robocop.config import DEFAULT_ISSUE_FORMAT, Config, ConfigManager, LinterConfig
@@ -154,6 +154,7 @@ def list_rules(
     """
     # TODO: support list-configurables (maybe as separate robocop rule <>)
     # TODO: rich support (colorized enabled, severity etc)
+    console = Console(soft_wrap=True)
     config_manager = ConfigManager()
     runner = RobocopLinter(config_manager)
     runner.check_for_disabled_rules()
@@ -164,11 +165,11 @@ def list_rules(
         rules = filter_rules_by_category(runner.rules, filter_category)
     severity_counter = {"E": 0, "W": 0, "I": 0}
     for rule in rules:
-        print(rule)
+        console.print(rule)
         severity_counter[rule.severity.value] += 1
     configurable_rules_sum = sum(severity_counter.values())
     plural = get_plural_form(configurable_rules_sum)
-    print(
+    console.print(
         f"\nAltogether {configurable_rules_sum} rule{plural} with following severity:\n"
         f"    {severity_counter['E']} error rule{get_plural_form(severity_counter['E'])},\n"
         f"    {severity_counter['W']} warning rule{get_plural_form(severity_counter['W'])},\n"
@@ -199,11 +200,12 @@ def list_reports(
     ] = None,
 ) -> None:
     """List available reports."""
+    console = Console(soft_wrap=True)
     linter_config = LinterConfig(reports=reports)
     config = Config(linter=linter_config)
     config_manager = ConfigManager(overwrite_config=config)
     runner = RobocopLinter(config_manager)
-    print(print_reports(runner.reports, enabled))  # TODO: color etc
+    console.print(print_reports(runner.reports, enabled))  # TODO: color etc
 
 
 @list_app.command(name="formatters")
@@ -221,12 +223,13 @@ def list_formatters(
 def describe_rule(rule: Annotated[str, typer.Argument(help="Rule name")]):
     """Describe a rule."""
     # TODO load external from cli
+    console = Console(soft_wrap=True)
     config_manager = ConfigManager()
     runner = RobocopLinter(config_manager)
     if rule not in runner.rules:
-        print(f"Rule '{rule}' does not exist.")
+        console.print(f"Rule '{rule}' does not exist.")
         raise typer.Exit(code=2)
-    print(runner.rules[rule].description_with_configurables)
+    console.print(runner.rules[rule].description_with_configurables)
 
 
 def main() -> None:

--- a/src/robocop/cli.py
+++ b/src/robocop/cli.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Optional
 
+from rich import print
 import typer
 
 from robocop.config import DEFAULT_ISSUE_FORMAT, Config, ConfigManager, LinterConfig
@@ -214,6 +215,18 @@ def list_formatters(
 ) -> None:
     """List available formatters."""
     # We will need ConfigManager later for listing based on configuration
+
+
+@app.command("rule")
+def describe_rule(rule: Annotated[str, typer.Argument(help="Rule name")]):
+    """Describe a rule."""
+    # TODO load external from cli
+    config_manager = ConfigManager()
+    runner = RobocopLinter(config_manager)
+    if rule not in runner.rules:
+        print(f"Rule '{rule}' does not exist.")
+        raise typer.Exit(code=2)
+    print(runner.rules[rule].description_with_configurables)
 
 
 def main() -> None:

--- a/src/robocop/linter/reports/__init__.py
+++ b/src/robocop/linter/reports/__init__.py
@@ -134,7 +134,7 @@ def print_reports(reports: dict[str, Report], only_enabled: bool | None) -> str:
         is_enabled = report.name in configured_reports
         if only_enabled is not None and only_enabled != is_enabled:
             continue
-        status = "enabled" if is_enabled else "disabled"
+        status = "[green]enabled[/green]" if is_enabled else "[red]disabled[/red]"
         if not is_report_default(report):
             status += " - non-default"
         available_reports += f"\n{report.name:20} - {report.description} ({status})"

--- a/src/robocop/linter/rules/__init__.py
+++ b/src/robocop/linter/rules/__init__.py
@@ -401,14 +401,22 @@ class Rule:
         self.config["enabled"].value = value
 
     @property
-    def description(self):
-        desc = ""
-        if not (self.msg.startswith("{{") and self.msg.endswith("}}")):
-            desc += f"{self.msg}."
+    def description(self) -> str:
+        """Description of the rule with rule name, message and documentation."""
+        description = f"Rule: [bold]{self.name}[/bold] ({self.rule_id})\n"
+        description += f"Message: {self.msg}\n"
+        description += f"Severity: {self.severity}\n"
         if self.docs:
-            desc += "\n"
-            desc += self.docs
-        return desc
+            description += self.docs
+        return description
+
+    @property
+    def description_with_configurables(self):
+        description = self.description
+        count, configurables = self.available_configurables(include_severity=False)
+        if not count:
+            return description
+        return f"{description}\nConfigurables:\n    {configurables}\n"
 
     @property
     def deprecation_warning(self) -> str:

--- a/tests/linter/cli/conftest.py
+++ b/tests/linter/cli/conftest.py
@@ -11,3 +11,10 @@ def empty_linter() -> RobocopLinter:
     runner.checkers = []
     runner.rules = {}
     return runner
+
+
+@pytest.fixture(scope="session")
+def loaded_linter() -> RobocopLinter:
+    config_manager = ConfigManager()
+    runner = RobocopLinter(config_manager)
+    return runner

--- a/tests/linter/cli/test_list_rules.py
+++ b/tests/linter/cli/test_list_rules.py
@@ -140,14 +140,15 @@ class TestListingRules:
             "    0 error rules,\n"
             "    1 warning rule,\n"
             "    0 info rules.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
+            "detailed documentation.\n"
         )
 
     def test_list_disabled_rule(self, empty_linter, msg_0101, msg_disabled_for_4, capsys):
         add_empty_checker(empty_linter, msg_0101, exclude=True)
         add_empty_checker(empty_linter, msg_disabled_for_4)
         if ROBOT_VERSION.major >= 4:
-            enabled_for = "disabled - supported only for RF version <4.0"
+            enabled_for = "disabled - supported only for \nRF version <4.0"
         else:
             enabled_for = "enabled"
         with patch("robocop.cli.RobocopLinter", MagicMock(return_value=empty_linter)):
@@ -160,7 +161,8 @@ class TestListingRules:
             "    0 error rules,\n"
             "    2 warning rules,\n"
             "    0 info rules.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
+            "detailed documentation.\n"
         )
 
     def test_list_filter_enabled(self, empty_linter, msg_0101, msg_0102_0204, capsys):
@@ -176,7 +178,8 @@ class TestListingRules:
             "    0 error rules,\n"
             "    1 warning rule,\n"
             "    0 info rules.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
+            "detailed documentation.\n"
         )
 
     def test_list_filter_disabled(self, empty_linter, msg_0101, msg_0102_0204, deprecated_rule, capsys):
@@ -193,7 +196,8 @@ class TestListingRules:
             "    1 error rule,\n"
             "    0 warning rules,\n"
             "    1 info rule.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
+            "detailed documentation.\n"
         )
 
     def test_list_filter_deprecated(self, empty_linter, msg_0101, msg_0102_0204, deprecated_rule, capsys):
@@ -205,12 +209,13 @@ class TestListingRules:
         out, _ = capsys.readouterr()
         assert (
             out == "Rule - 9991 [E]: deprecated-rule: Deprecated rule (deprecated)\n"
-            "Rule - 9992 [I]: deprecated-disabled-rule: Deprecated and disabled rule (deprecated)\n\n"
+            "Rule - 9992 [I]: deprecated-disabled-rule: Deprecated and disabled rule \n(deprecated)\n\n"
             "Altogether 2 rules with following severity:\n"
             "    1 error rule,\n"
             "    0 warning rules,\n"
             "    1 info rule.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
+            "detailed documentation.\n"
         )
 
     def test_multiple_checkers(self, empty_linter, msg_0101, msg_0102_0204, capsys):
@@ -255,7 +260,8 @@ class TestListingRules:
             "    0 error rules,\n"
             "    2 warning rules,\n"
             "    0 info rules.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
+            "detailed documentation.\n"
         )
 
     # def test_list_configurables(self, empty_linter, msg_0101_config_meta, capsys):  # TODO

--- a/tests/linter/cli/test_list_rules.py
+++ b/tests/linter/cli/test_list_rules.py
@@ -140,15 +140,14 @@ class TestListingRules:
             "    0 error rules,\n"
             "    1 warning rule,\n"
             "    0 info rules.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
-            "detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
         )
 
     def test_list_disabled_rule(self, empty_linter, msg_0101, msg_disabled_for_4, capsys):
         add_empty_checker(empty_linter, msg_0101, exclude=True)
         add_empty_checker(empty_linter, msg_disabled_for_4)
         if ROBOT_VERSION.major >= 4:
-            enabled_for = "disabled - supported only for \nRF version <4.0"
+            enabled_for = "disabled - supported only for RF version <4.0"
         else:
             enabled_for = "enabled"
         with patch("robocop.cli.RobocopLinter", MagicMock(return_value=empty_linter)):
@@ -161,8 +160,7 @@ class TestListingRules:
             "    0 error rules,\n"
             "    2 warning rules,\n"
             "    0 info rules.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
-            "detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
         )
 
     def test_list_filter_enabled(self, empty_linter, msg_0101, msg_0102_0204, capsys):
@@ -178,8 +176,7 @@ class TestListingRules:
             "    0 error rules,\n"
             "    1 warning rule,\n"
             "    0 info rules.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
-            "detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
         )
 
     def test_list_filter_disabled(self, empty_linter, msg_0101, msg_0102_0204, deprecated_rule, capsys):
@@ -196,8 +193,7 @@ class TestListingRules:
             "    1 error rule,\n"
             "    0 warning rules,\n"
             "    1 info rule.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
-            "detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
         )
 
     def test_list_filter_deprecated(self, empty_linter, msg_0101, msg_0102_0204, deprecated_rule, capsys):
@@ -209,13 +205,12 @@ class TestListingRules:
         out, _ = capsys.readouterr()
         assert (
             out == "Rule - 9991 [E]: deprecated-rule: Deprecated rule (deprecated)\n"
-            "Rule - 9992 [I]: deprecated-disabled-rule: Deprecated and disabled rule \n(deprecated)\n\n"
+            "Rule - 9992 [I]: deprecated-disabled-rule: Deprecated and disabled rule (deprecated)\n\n"
             "Altogether 2 rules with following severity:\n"
             "    1 error rule,\n"
             "    0 warning rules,\n"
             "    1 info rule.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
-            "detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
         )
 
     def test_multiple_checkers(self, empty_linter, msg_0101, msg_0102_0204, capsys):
@@ -260,8 +255,7 @@ class TestListingRules:
             "    0 error rules,\n"
             "    2 warning rules,\n"
             "    0 info rules.\n\n"
-            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for \n"
-            "detailed documentation.\n"
+            "Visit https://robocop.readthedocs.io/en/stable/rules_list.html page for detailed documentation.\n"
         )
 
     # def test_list_configurables(self, empty_linter, msg_0101_config_meta, capsys):  # TODO

--- a/tests/linter/cli/test_rule.py
+++ b/tests/linter/cli/test_rule.py
@@ -1,0 +1,67 @@
+import textwrap
+from unittest.mock import MagicMock, patch
+
+from robocop.cli import describe_rule
+
+from tests.linter.cli.conftest import loaded_linter
+
+
+class TestDescribeRule:
+    def test_describe_rule(self, loaded_linter, capsys):
+        with patch("robocop.cli.RobocopLinter", MagicMock(return_value=loaded_linter)):
+            describe_rule("duplicated-keyword")
+        out, _ = capsys.readouterr()
+        expected = textwrap.dedent("""
+        Rule: duplicated-keyword (0802)
+        Message: Multiple keywords with name '{{ name }}' (first occurrence in line {{ 
+        first_occurrence_line }})
+        Severity: E
+
+        Do not define keywords with the same name inside the same file. Name matching 
+        is case-insensitive and
+        ignores spaces and underscore characters.
+        Duplicated keyword names example::
+
+            *** Keywords ***
+            Keyword
+                No Operation
+    
+            keyword
+                No Operation
+    
+            K_eywor d
+                No Operation
+
+
+        """).lstrip()
+        assert expected == out
+
+    def test_describe_rule_with_configurables(self, loaded_linter, capsys):
+        with patch("robocop.cli.RobocopLinter", MagicMock(return_value=loaded_linter)):
+            describe_rule("line-too-long")
+        out, _ = capsys.readouterr()
+        expected = textwrap.dedent("""
+        Rule: line-too-long (0508)
+        Message: Line is too long ({{ line_length }}/{{ allowed_length }})
+        Severity: W
+
+        It is possible to ignore lines that match regex pattern. Configure it using 
+        following option::
+        
+            robocop --configure line-too-long:ignore_pattern:pattern
+        
+        The default pattern is ``https?://\\S+`` that ignores the lines that look like 
+        an URL.
+        
+        
+        Configurables:
+            line_length = 120
+                type: int
+                info: number of characters allowed in line
+            ignore_pattern = re.compile('https?://\\\\S+')
+                type: pattern_type
+                info: ignore lines that contain configured pattern
+            severity_threshold
+
+        """).lstrip()
+        assert expected == out

--- a/tests/linter/cli/test_rule.py
+++ b/tests/linter/cli/test_rule.py
@@ -13,12 +13,10 @@ class TestDescribeRule:
         out, _ = capsys.readouterr()
         expected = textwrap.dedent("""
         Rule: duplicated-keyword (0802)
-        Message: Multiple keywords with name '{{ name }}' (first occurrence in line {{ 
-        first_occurrence_line }})
+        Message: Multiple keywords with name '{{ name }}' (first occurrence in line {{ first_occurrence_line }})
         Severity: E
 
-        Do not define keywords with the same name inside the same file. Name matching 
-        is case-insensitive and
+        Do not define keywords with the same name inside the same file. Name matching is case-insensitive and
         ignores spaces and underscore characters.
         Duplicated keyword names example::
 
@@ -45,13 +43,11 @@ class TestDescribeRule:
         Message: Line is too long ({{ line_length }}/{{ allowed_length }})
         Severity: W
 
-        It is possible to ignore lines that match regex pattern. Configure it using 
-        following option::
+        It is possible to ignore lines that match regex pattern. Configure it using following option::
         
             robocop --configure line-too-long:ignore_pattern:pattern
         
-        The default pattern is ``https?://\\S+`` that ignores the lines that look like 
-        an URL.
+        The default pattern is ``https?://\\S+`` that ignores the lines that look like an URL.
         
         
         Configurables:


### PR DESCRIPTION
New command that describes the rule. It uses rule name, message, documentation and optional configurables to recreate description similiar to the one from the online documentation.