### PR TITLE
Rename --include to --select and --exclude to --ignore

### DIFF
--- a/src/robocop/cli.py
+++ b/src/robocop/cli.py
@@ -4,7 +4,7 @@ from typing import Annotated, Optional
 import typer
 from rich.console import Console
 
-from robocop import config
+from robocop import config, files
 from robocop.formatter.runner import RobocopFormatter
 from robocop.linter.reports import print_reports
 from robocop.linter.rules import RuleFilter, RuleSeverity, filter_rules_by_category, filter_rules_by_pattern
@@ -54,8 +54,12 @@ def parse_rule_severity(value: str):
 @app.command(name="check")
 def check_files(
     sources: Annotated[list[Path], typer.Argument(show_default="current directory")] = None,
-    include: Annotated[list[str], typer.Option("--include", "-i", show_default=False)] = None,
-    exclude: Annotated[list[str], typer.Option("--exclude", "-e", show_default=False)] = None,
+    include: Annotated[list[str], typer.Option("--include", "-i", show_default=str(files.DEFAULT_INCLUDE))] = None,
+    extend_include: Annotated[list[str], typer.Option("--extend-include", show_default=False)] = None,
+    exclude: Annotated[list[str], typer.Option("--exclude", "-e", show_default=str(files.DEFAULT_EXCLUDE))] = None,
+    extend_exclude: Annotated[list[str], typer.Option("--extend-exclude", show_default=False)] = None,
+    select: Annotated[list[str], typer.Option("--select", "-s", show_default=False)] = None,
+    ignore: Annotated[list[str], typer.Option("--ignore", "-ig", show_default=False)] = None,
     threshold: Annotated[
         RuleSeverity,
         typer.Option(
@@ -112,8 +116,8 @@ def check_files(
     """Lint files."""
     linter_config = config.LinterConfig(
         configure=configure,
-        include=include,
-        exclude=exclude,
+        select=select,
+        ignore=ignore,
         issue_format=issue_format,
         threshold=threshold,
         ext_rules=ext_rules,

--- a/src/robocop/config.py
+++ b/src/robocop/config.py
@@ -83,8 +83,8 @@ class WhitespaceConfig:
 @dataclass
 class LinterConfig:
     configure: list[str] = field(default_factory=list)
-    include: list[str] = field(default_factory=list)
-    exclude: list[str] = field(default_factory=list)
+    select: list[str] = field(default_factory=list)
+    ignore: list[str] = field(default_factory=list)
     issue_format: str = DEFAULT_ISSUE_FORMAT
     threshold: RuleSeverity | None = RuleSeverity.INFO
     ext_rules: list[str] = field(default_factory=list)
@@ -103,15 +103,15 @@ class LinterConfig:
         We need to remove optional severity and split it into patterns and not patterns for easier filtering.
 
         """
-        if self.include:
-            for rule in self.include:
+        if self.select:
+            for rule in self.select:
                 rule_without_sev = replace_severity_values(rule)
                 if "*" in rule_without_sev:
                     self.include_rules_patterns.add(compile_rule_pattern(rule_without_sev))
                 else:
                     self.include_rules.add(rule_without_sev)
-        if self.exclude:
-            for rule in self.exclude:
+        if self.ignore:
+            for rule in self.ignore:
                 rule_without_sev = replace_severity_values(rule)
                 if "*" in rule_without_sev:
                     self.exclude_rules_patterns.add(compile_rule_pattern(rule_without_sev))

--- a/src/robocop/files.py
+++ b/src/robocop/files.py
@@ -16,6 +16,8 @@ except ImportError:  # from Python 3.11
 
 
 CONFIG_NAMES = frozenset(("robotidy.toml", "pyproject.toml"))
+DEFAULT_INCLUDE = ("*.robot", "*.resource")
+DEFAULT_EXCLUDE = (".direnv", ".eggs", ".git", ".svn", ".hg", ".nox", ".tox", ".venv", "venv", "dist")
 INCLUDE_EXT = (".robot", ".resource")
 
 
@@ -98,12 +100,12 @@ def find_source_config_file(src: Path, ignore_git_dir: bool = False) -> Path | N
     returns ``None``.
     """
     if src.is_dir():
-        if not ignore_git_dir and src.name == ".git":
-            return None
         for config_filename in CONFIG_NAMES:
             if (src / config_filename).is_file():
                 return src / config_filename
         if not src.parents:
+            return None
+        if not ignore_git_dir and (src.parent / ".git").is_dir():
             return None
     return find_source_config_file(src.parent, ignore_git_dir)
 

--- a/tests/config/test_rule_matcher.py
+++ b/tests/config/test_rule_matcher.py
@@ -22,22 +22,22 @@ def get_message_with_id(rule_id):
 
 class TestIncludingExcluding:
     @pytest.mark.parametrize(
-        ("included", "excluded"),
+        ("selected", "ignored"),
         [
             (["0101"], ["0102", "0501", "0402"]),
             (["W0101", "0102"], ["0501", "0402"]),
             (["E0501", "I0402"], ["0101", "0102"]),
         ],
     )
-    def test_only_included(self, included, excluded):
-        linter_config = LinterConfig(include=included, exclude=excluded)
+    def test_only_selected(self, selected, ignored):
+        linter_config = LinterConfig(select=selected, ignore=ignored)
         config = Config(linter=linter_config)
         rule_matcher = RuleMatcher(config)
-        assert all(rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in included)
-        assert all(not rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in excluded)
+        assert all(rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in selected)
+        assert all(not rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in ignored)
 
     @pytest.mark.parametrize(
-        ("patterns", "included", "excluded"),
+        ("patterns", "selected", "ignored"),
         [
             (["01*"], [], ["0202", "0501", "0403"]),
             (["01*", "*5"], ["0101", "0105", "0405"], ["0204", "0402"]),
@@ -45,30 +45,30 @@ class TestIncludingExcluding:
             (["*"], ["0101", "0105", "0204", "0405", "0405"], []),
         ],
     )
-    def test_only_included_patterns(self, patterns, included, excluded):
-        linter_config = LinterConfig(include=patterns)
+    def test_only_selected_patterns(self, patterns, selected, ignored):
+        linter_config = LinterConfig(select=patterns)
         config = Config(linter=linter_config)
         rule_matcher = RuleMatcher(config)
-        assert all(rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in included)
-        assert all(not rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in excluded)
+        assert all(rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in selected)
+        assert all(not rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in ignored)
 
     @pytest.mark.parametrize(
-        ("included", "excluded"),
+        ("selected", "ignored"),
         [
             (["0101"], ["0102", "0501", "0402"]),
             (["W0101", "0102"], ["0501", "0402"]),
             (["E0501", "I0402"], ["0101", "0102"]),
         ],
     )
-    def test_only_excluded(self, included, excluded):
-        linter_config = LinterConfig(exclude=excluded)
+    def test_only_ignored(self, selected, ignored):
+        linter_config = LinterConfig(ignore=ignored)
         config = Config(linter=linter_config)
         rule_matcher = RuleMatcher(config)
-        assert all(rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in included)
-        assert all(not rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in excluded)
+        assert all(rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in selected)
+        assert all(not rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in ignored)
 
     @pytest.mark.parametrize(
-        ("patterns", "included", "excluded"),
+        ("patterns", "selected", "ignored"),
         [
             (["01*"], ["0204", "0405", "0405"], ["0101", "0105"]),
             (["01*", "*5"], ["0204"], ["0101", "0105", "0405", "0405"]),
@@ -76,19 +76,19 @@ class TestIncludingExcluding:
             (["*"], [], ["0101", "0105", "0204", "0405", "0405"]),
         ],
     )
-    def test_only_excluded_patterns(self, patterns, included, excluded):
+    def test_only_ignored_patterns(self, patterns, selected, ignored):
         """
         Test data contains rules with rule id's "0101", "0105", "0204", "0405", "0405"
         and rule names created using `some-message-{rule_id}` pattern
         """
-        linter_config = LinterConfig(exclude=excluded)
+        linter_config = LinterConfig(ignore=ignored)
         config = Config(linter=linter_config)
         rule_matcher = RuleMatcher(config)
-        assert all(rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in included)
-        assert all(not rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in excluded)
+        assert all(rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in selected)
+        assert all(not rule_matcher.is_rule_enabled(get_message_with_id(msg)) for msg in ignored)
 
-    def test_both_included_excluded(self):
-        linter_config = LinterConfig(include=["0101"], exclude=["W0101"])
+    def test_both_selected_excluded(self):
+        linter_config = LinterConfig(select=["0101"], ignore=["W0101"])
         config = Config(linter=linter_config)
         rule_matcher = RuleMatcher(config)
         msg = get_message_with_id("0101")

--- a/tests/linter/utils/__init__.py
+++ b/tests/linter/utils/__init__.py
@@ -71,7 +71,7 @@ class RuleAcceptance:
         expected_file: str | None = None,
         configure: list[str] | None = None,
         threshold: RuleSeverity | None = None,
-        include: list[str] | None = None,
+        select: list[str] | None = None,
         src_files: list | None = None,
         target_version: str | list[str] | None = None,
         issue_format: str = "default",
@@ -84,8 +84,8 @@ class RuleAcceptance:
         test_data = self.test_class_dir
         expected = load_expected_file(test_data, expected_file)
         issue_format = self.get_issue_format(issue_format)
-        if include is None:
-            include = [self.rule_name]
+        if select is None:
+            select = [self.rule_name]
         if src_files is None:
             paths = [test_data]
         else:
@@ -95,7 +95,7 @@ class RuleAcceptance:
                 with pytest.raises(click.exceptions.Exit):
                     check_files(
                         sources=paths,
-                        include=include,
+                        select=select,
                         configure=configure,
                         issue_format=issue_format,
                         threshold=threshold,


### PR DESCRIPTION
Both robotidy and robocop use options such as include/ignore.. for different purpose. Additionaly, ``--include`` does not rely the meaning fully ('select' and only run selected rules/formatters). The rename to ``--select``, ``--ignore` (for rules/formatters)`, ``--include`` and ``--exclude`` (for files) normalizes this situation.

The documentation and release docs will be added separetely.