### PR TITLE
Add --target-version option

### DIFF
--- a/docs/releasenotes/6.0.0dev1.rst
+++ b/docs/releasenotes/6.0.0dev1.rst
@@ -93,6 +93,21 @@ Use implicit name of the formatter instead::
 
     robocop format --configure MyFormatter.param=2
 
+Renamed options from Robotidy
+------------------------------
+
+Following options from Robotidy are now available in robocop under different name:
+
+- ``--lineseparator`` -> ``--line-ending``
+- ``--startline`` -> ``--start-line``
+- ``--endline`` -> ``--end-line``
+
+--target-version different input syntax
+---------------------------------------
+
+Formatter ``--target-version`` can now only accept numbers. Previous configuration such as ``--target-version RF5``
+should be now ``--target-version 5``.
+
 return_status report is now optional
 -------------------------------------
 

--- a/src/robocop/cli.py
+++ b/src/robocop/cli.py
@@ -168,6 +168,7 @@ def format_files(
     ] = None,
     configuration_file: config_option = None,
     overwrite: bool = None,
+    diff: bool = None,
     check: bool = None,
     output: Path = None,
     language: Annotated[
@@ -184,8 +185,11 @@ def format_files(
     indent: Annotated[int, typer.Option(show_default="same as space-count")] = None,
     continuation_indent: Annotated[int, typer.Option(show_default="same as space-count")] = None,
     line_length: Annotated[int, typer.Option(show_default="120")] = None,
+    separator: Annotated[str, typer.Option(show_default="space")] = None,
+    line_ending: Annotated[str, typer.Option(show_default="native")] = None,
     start_line: Annotated[int, typer.Option(show_default=False)] = None,
     end_line: Annotated[int, typer.Option(show_default=False)] = None,
+    target_version: Annotated[config.TargetVersion, typer.Option(case_sensitive=False)] = None,
     ignore_git_dir: Annotated[bool, typer.Option()] = False,
     skip_gitignore: Annotated[bool, typer.Option()] = False,
     root: project_root_option = None,
@@ -195,8 +199,8 @@ def format_files(
         space_count=space_count,  # TODO
         indent=indent,
         continuation_indent=continuation_indent,
-        line_separator=None,
-        separator=None,
+        line_ending=line_ending,
+        separator=separator,
         line_length=line_length,
     )
     formatter_config = config.FormatterConfig(
@@ -206,9 +210,11 @@ def format_files(
         configure=configure,
         overwrite=overwrite,
         output=output,
+        show_diff=diff,
         check=check,
         start_line=start_line,
         end_line=end_line,
+        target_version=target_version,
     )
     file_filters = config.FileFiltersOptions(
         include=include, extend_include=extend_include, exclude=exclude, extend_exclude=extend_exclude

--- a/src/robocop/formatter/config.py
+++ b/src/robocop/formatter/config.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import copy
-import dataclasses
 import os
 import re
 import sys
-from collections import namedtuple
 from dataclasses import dataclass, field
 from pathlib import Path
 from re import Pattern
@@ -23,100 +21,6 @@ from robocop.formatter.formatters import FormatConfig, FormatConfigMap, convert_
 from robocop.formatter.utils import misc
 
 
-class FormattingConfig:
-    def __init__(
-        self,
-        space_count: int,
-        indent: int | None,
-        continuation_indent: int | None,
-        line_sep: str,
-        start_line: int | None,
-        end_line: int | None,
-        separator: str,
-        line_length: int,
-    ):
-        self.start_line = start_line
-        self.end_line = end_line
-        self.space_count = space_count
-        self.line_length = line_length
-
-        if indent is None:
-            indent = space_count
-        if continuation_indent is None:
-            continuation_indent = space_count
-
-        if separator == "space":
-            self.separator = " " * space_count
-            self.indent = " " * indent
-            self.continuation_indent = " " * continuation_indent
-        elif separator == "tab":
-            self.separator = "\t"
-            self.indent = "\t"
-            self.continuation_indent = "\t"
-
-        self.line_sep = self.get_line_sep(line_sep)
-
-    @staticmethod
-    def get_line_sep(line_sep):
-        if line_sep == "windows":
-            return "\r\n"
-        if line_sep == "unix":
-            return "\n"
-        if line_sep == "auto":
-            return "auto"
-        return os.linesep
-
-
-def validate_target_version(value: str | None) -> int | None:
-    if value is None:
-        return misc.ROBOT_VERSION.major
-    try:
-        target_version = misc.TargetVersion[value.upper()].value
-    except KeyError:
-        versions = ", ".join(ver.value for ver in misc.TargetVersion)
-        raise click.BadParameter(f"Invalid target Robot Framework version: '{value}' is not one of {versions}")
-    if target_version > misc.ROBOT_VERSION.major:
-        raise click.BadParameter(
-            f"Target Robot Framework version ({target_version}) should not be higher than "
-            f"installed version ({misc.ROBOT_VERSION})."
-        )
-    return target_version
-
-
-def csv_list_type(value: str | None) -> list[str]:
-    if not value:
-        return []
-    return value.split(",")
-
-
-def convert_formatters_config(
-    param_name: str,
-    config: dict,
-    force_included: bool = False,
-    custom_formatter: bool = False,
-    is_config: bool = False,
-) -> list[FormatConfig]:
-    return [
-        FormatConfig(tr, force_include=force_included, custom_formatter=custom_formatter, is_config=is_config)
-        for tr in config.get(param_name, ())
-    ]
-
-
-def str_to_bool(v):
-    if isinstance(v, bool):
-        return v
-    return v.lower() in ("yes", "true", "1")
-
-
-def map_class_fields_with_their_types(cls):
-    """Returns map of dataclass attributes with their types."""
-    fields = dataclasses.fields(cls)
-    return {field.name: field.type for field in fields}
-
-
-SourceAndConfig = namedtuple("SourceAndConfig", "source config")
-
-
 @dataclass
 class RawConfig:
     """Configuration read directly from cli or configuration file."""
@@ -132,18 +36,9 @@ class RawConfig:
     diff: bool = False
     color: bool = True
     check: bool = False
-    spacecount: int = 4
-    indent: int = None
-    continuation_indent: int = None
-    lineseparator: str = "native"
+
     verbose: bool = False
-    config: str = None
-    config_path: Path = None
-    separator: str = "space"
-    startline: int = None
-    endline: int = None
-    line_length: int = 120
-    list_formatters: str = ""
+
     generate_config: str = ""
     desc: str = None
     output: Path = None

--- a/src/robocop/formatter/runner.py
+++ b/src/robocop/formatter/runner.py
@@ -140,7 +140,7 @@ class RobocopFormatter:
             misc.ModelWriter(output=output, newline=self.get_line_ending(source)).write(model)
 
     def get_line_ending(self, path: str):
-        if self.config.formatter.whitespace_config.line_separator == "auto":
+        if self.config.formatter.whitespace_config.line_ending == "auto":
             with open(path) as f:
                 f.readline()
                 if f.newlines is None:
@@ -148,7 +148,7 @@ class RobocopFormatter:
                 if isinstance(f.newlines, str):
                     return f.newlines
                 return f.newlines[0]
-        return self.config.formatter.whitespace_config.line_separator
+        return self.config.formatter.whitespace_config.line_ending
 
     def output_diff(self, path: Path, old_model: misc.StatementLinesCollector, new_model: misc.StatementLinesCollector):
         if not self.config.formatter.show_diff:

--- a/src/robocop/formatter/utils/misc.py
+++ b/src/robocop/formatter/utils/misc.py
@@ -5,7 +5,6 @@ import difflib
 import os
 import re
 from collections.abc import Iterable
-from enum import Enum
 from functools import total_ordering
 from re import Pattern
 
@@ -56,13 +55,6 @@ ROBOT_VERSION = Version.parse(RF_VERSION)
 
 def rf_supports_lang():
     return ROBOT_VERSION.major >= 6
-
-
-class TargetVersion(Enum):
-    RF4 = 4
-    RF5 = 5
-    RF6 = 6
-    RF7 = 7
 
 
 class StatementLinesCollector(ModelVisitor):

--- a/tests/formatter/__init__.py
+++ b/tests/formatter/__init__.py
@@ -44,7 +44,7 @@ class FormatterAcceptanceTest:
         not_modified: bool = False,
         expected: str | None = None,
         configure: list[str] = "",
-        target_version: str | None = None,
+        test_on_version: str | None = None,
         run_all: bool = False,
         select: list[str] = None,
         **kwargs,
@@ -66,7 +66,7 @@ class FormatterAcceptanceTest:
             configure=configure,
             source=source,
             not_modified=not_modified,
-            target_version=target_version,
+            test_on_version=test_on_version,
             **kwargs,
         )
         if not not_modified:
@@ -79,11 +79,11 @@ class FormatterAcceptanceTest:
         source: str = None,
         exit_code: int = 0,
         not_modified: bool = False,
-        target_version: str | None = None,
+        test_on_version: str | None = None,
         **kwargs,
     ):
-        if not self.enabled_in_version(target_version):
-            pytest.skip(f"Test enabled only for RF {target_version}")
+        if not self.enabled_in_version(test_on_version):
+            pytest.skip(f"Test enabled only for RF {test_on_version}")
         output_path = self.FORMATTERS_DIR / "actual" / source
         if source is None:
             source_path = self.FORMATTERS_DIR / self.FORMATTER_NAME / "source"

--- a/tests/formatter/formatters/AddMissingEnd/test_formatter.py
+++ b/tests/formatter/formatters/AddMissingEnd/test_formatter.py
@@ -11,7 +11,7 @@ class TestAddMissingEnd(FormatterAcceptanceTest):
         self.compare(source="test.robot", expected="test_selected.robot", start_line=166, end_line=188)
 
     def test_rf5_syntax(self):
-        self.compare(source="test_5.robot", target_version=">=5")
+        self.compare(source="test_5.robot", test_on_version=">=5")
 
     def test_disablers(self):
-        self.compare(source="test_5_disablers.robot", target_version=">=5", not_modified=True)
+        self.compare(source="test_5_disablers.robot", test_on_version=">=5", not_modified=True)

--- a/tests/formatter/formatters/AlignKeywordsSection/test_formatter.py
+++ b/tests/formatter/formatters/AlignKeywordsSection/test_formatter.py
@@ -26,13 +26,13 @@ class TestAlignKeywordsSection(FormatterAcceptanceTest):
         )
 
     def test_blocks_rf5(self):
-        self.compare(source="blocks_rf5.robot", target_version=">=5")
+        self.compare(source="blocks_rf5.robot", test_on_version=">=5")
 
     def test_one_column(self):
         self.compare(source="one_column.robot")
 
     def test_invalid(self):
-        self.compare(source="non_ascii_spaces.robot", target_version=">=5")
+        self.compare(source="non_ascii_spaces.robot", test_on_version=">=5")
 
     @pytest.mark.parametrize(
         "widths",
@@ -126,7 +126,7 @@ class TestAlignKeywordsSection(FormatterAcceptanceTest):
         self.compare(source="too_long_line_disablers.robot", select=["SplitTooLongLine"])
 
     def test_error_node(self):
-        self.compare(source="error_node.robot", not_modified=True, target_version=">=5")
+        self.compare(source="error_node.robot", not_modified=True, test_on_version=">=5")
 
     def test_skip_return_values(self):
         configure = [

--- a/tests/formatter/formatters/AlignTestCasesSection/test_formatter.py
+++ b/tests/formatter/formatters/AlignTestCasesSection/test_formatter.py
@@ -23,13 +23,13 @@ class TestAlignTestCasesSection(FormatterAcceptanceTest):
         self.compare(source="blocks.robot", expected="blocks_auto_0.robot", configure=configure)
 
     def test_blocks_rf5(self):
-        self.compare(source="blocks_rf5.robot", target_version=">=5")
+        self.compare(source="blocks_rf5.robot", test_on_version=">=5")
 
     def test_one_column(self):
         self.compare(source="one_column.robot")
 
     def test_invalid(self):
-        self.compare(source="non_ascii_spaces.robot", target_version=">=5")
+        self.compare(source="non_ascii_spaces.robot", test_on_version=">=5")
 
     @pytest.mark.parametrize(
         "widths",

--- a/tests/formatter/formatters/ExternalTransformer/ExternalTransformers/custom_class.py
+++ b/tests/formatter/formatters/ExternalTransformer/ExternalTransformers/custom_class.py
@@ -1,4 +1,5 @@
 from robot.api import Token
+
 from robocop.formatter.formatters import Formatter
 
 

--- a/tests/formatter/formatters/GenerateDocumentation/test_formatter.py
+++ b/tests/formatter/formatters/GenerateDocumentation/test_formatter.py
@@ -12,17 +12,17 @@ class TestGenerateDocumentation(FormatterAcceptanceTest):
     FORMATTER_NAME = "GenerateDocumentation"
 
     def test_transformer(self):
-        self.compare(source="test.robot", target_version=">=5")
+        self.compare(source="test.robot", test_on_version=">=5")
 
     def test_transformer_rf4(self):
-        self.compare(source="test.robot", expected="test_rf4.robot", target_version="<=4")
+        self.compare(source="test.robot", expected="test_rf4.robot", test_on_version="<=4")
 
     def test_transformer_overwrite(self):
         self.compare(
             source="test.robot",
             expected="overwrite.robot",
             configure=[f"{self.FORMATTER_NAME}.overwrite=True"],
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_template_with_defaults(self):
@@ -32,7 +32,7 @@ class TestGenerateDocumentation(FormatterAcceptanceTest):
             select=[self.FORMATTER_NAME],
             configure=[f"{self.FORMATTER_NAME}.doc_template={template_path}"],
             source=source,
-            target_version=">=5",
+            test_on_version=">=5",
         )
         self.compare_file(source, "template_with_defaults.robot")
 
@@ -44,7 +44,7 @@ class TestGenerateDocumentation(FormatterAcceptanceTest):
             select=[self.FORMATTER_NAME],
             configure=[f"{self.FORMATTER_NAME}.doc_template={rel_template_path}"],
             source=source,
-            target_version=">=5",
+            test_on_version=">=5",
         )
         self.compare_file(source, "template_with_defaults.robot")
 

--- a/tests/formatter/formatters/MergeAndOrderSections/test_formatter.py
+++ b/tests/formatter/formatters/MergeAndOrderSections/test_formatter.py
@@ -1,4 +1,3 @@
-
 from tests.formatter import FormatterAcceptanceTest
 
 
@@ -9,10 +8,10 @@ class TestMergeAndOrderSections(FormatterAcceptanceTest):
         self.compare(source="tests.robot")
 
     def test_both_test_and_task(self):
-        self.compare(source="both_test_and_task.robot", target_version="<6")
+        self.compare(source="both_test_and_task.robot", test_on_version="<6")
 
     def test_both_test_and_task_rf6(self):
-        self.compare(source="both_test_and_task.robot", expected="both_test_and_task_rf6.robot", target_version=">=6")
+        self.compare(source="both_test_and_task.robot", expected="both_test_and_task_rf6.robot", test_on_version=">=6")
 
     def test_multiple_header_comments(self):
         self.compare(source="multiple_header_comments.robot")
@@ -81,7 +80,7 @@ class TestMergeAndOrderSections(FormatterAcceptanceTest):
         self.compare(source="disablers.robot")
 
     def test_translated(self):
-        self.compare(source="translated.robot", target_version=">=6")
+        self.compare(source="translated.robot", test_on_version=">=6")
 
     def test_invalid(self):
-        self.compare(source="invalid.robot", not_modified=True, target_version=">=6.1")
+        self.compare(source="invalid.robot", not_modified=True, test_on_version=">=6.1")

--- a/tests/formatter/formatters/NormalizeNewLines/test_formatter.py
+++ b/tests/formatter/formatters/NormalizeNewLines/test_formatter.py
@@ -49,7 +49,9 @@ class TestNormalizeNewLines(FormatterAcceptanceTest):
 
     @pytest.mark.parametrize("trailing_lines", [0, 1, 2])
     def test_inline_if(self, trailing_lines):
-        self.compare(source=f"inline_if_{trailing_lines}_lines.robot", expected="inline_if.robot", target_version=">=5")
+        self.compare(
+            source=f"inline_if_{trailing_lines}_lines.robot", expected="inline_if.robot", test_on_version=">=5"
+        )
 
     def test_disablers(self):
         self.compare(source="disablers.robot", not_modified=True)
@@ -58,15 +60,15 @@ class TestNormalizeNewLines(FormatterAcceptanceTest):
         self.compare(source="disablers_selected.robot")
 
     def test_blocks(self):
-        self.compare(source="blocks.robot", target_version=">=5")
+        self.compare(source="blocks.robot", test_on_version=">=5")
 
     def test_remove_empty_multiline(self):
         self.compare(source="multiline.robot")
 
     def test_language_header(self):
-        self.compare(source="language_header_0empty.robot", target_version=">=6")
-        self.compare(source="language_header_2empty.robot", target_version=">=6")
+        self.compare(source="language_header_0empty.robot", test_on_version=">=6")
+        self.compare(source="language_header_2empty.robot", test_on_version=">=6")
         self.compare(
-            source="language_header_5empty.robot", expected="language_header_2empty.robot", target_version=">=6"
+            source="language_header_5empty.robot", expected="language_header_2empty.robot", test_on_version=">=6"
         )
-        self.compare(source="language_header_and_comments.robot", target_version=">=6")
+        self.compare(source="language_header_and_comments.robot", test_on_version=">=6")

--- a/tests/formatter/formatters/NormalizeSectionHeaderName/test_formatter.py
+++ b/tests/formatter/formatters/NormalizeSectionHeaderName/test_formatter.py
@@ -25,4 +25,4 @@ class TestNormalizeSectionHeaderName(FormatterAcceptanceTest):
         self.compare(source="disablers.robot", not_modified=True)
 
     def test_translated(self):
-        self.compare(source="translated.robot", target_version=">=6")
+        self.compare(source="translated.robot", test_on_version=">=6")

--- a/tests/formatter/formatters/NormalizeSeparators/test_formatter.py
+++ b/tests/formatter/formatters/NormalizeSeparators/test_formatter.py
@@ -37,7 +37,7 @@ class TestNormalizeSeparators(FormatterAcceptanceTest):
             )
 
     def test_rf5_syntax(self):
-        self.compare(source="rf5_syntax.robot", target_version=">=5")
+        self.compare(source="rf5_syntax.robot", test_on_version=">=5")
 
     @pytest.mark.parametrize(
         "disablers", ["disablers.robot", "disablers2.robot", "disablers3.robot", "disablers4.robot"]
@@ -66,7 +66,7 @@ class TestNormalizeSeparators(FormatterAcceptanceTest):
             expected=f"inline_if_{indent}indent_{spaces}spaces.robot",
             space_count=spaces,
             indent=indent,
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_inline_if_flatten(self):
@@ -76,7 +76,7 @@ class TestNormalizeSeparators(FormatterAcceptanceTest):
             space_count=4,
             indent=4,
             configure=[f"{self.FORMATTER_NAME}.flatten_lines=True"],
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_skip_keyword_call(self):
@@ -92,17 +92,17 @@ class TestNormalizeSeparators(FormatterAcceptanceTest):
     def test_skip_comments(self):
         configure = [f"{self.FORMATTER_NAME}.skip_comments=True"]
         expected = "comments_skip_comments.robot"
-        self.compare(source="comments.robot", expected=expected, configure=configure, target_version=">=5")
+        self.compare(source="comments.robot", expected=expected, configure=configure, test_on_version=">=5")
 
     def test_skip_block_comments(self):
         configure = [f"{self.FORMATTER_NAME}.skip_block_comments=True"]
         expected = "comments_skip_block_comments.robot"
-        self.compare(source="comments.robot", expected=expected, configure=configure, target_version=">=5")
+        self.compare(source="comments.robot", expected=expected, configure=configure, test_on_version=">=5")
 
     def test_skip_all_comments(self):
         configure = [f"{self.FORMATTER_NAME}.skip_comments=True", f"{self.FORMATTER_NAME}.skip_block_comments=True"]
         expected = "comments_skip_comments.robot"
-        self.compare(source="comments.robot", expected=expected, configure=configure, target_version=">=5")
+        self.compare(source="comments.robot", expected=expected, configure=configure, test_on_version=">=5")
 
     def test_flatten_lines(self):
         if ROBOT_VERSION.major > 4:

--- a/tests/formatter/formatters/NormalizeSettingName/test_formatter.py
+++ b/tests/formatter/formatters/NormalizeSettingName/test_formatter.py
@@ -19,7 +19,7 @@ class TestNormalizeSettingName(FormatterAcceptanceTest):
         self.compare(source="disablers.robot", not_modified=True)
 
     def test_translated(self):
-        self.compare(source="translated.robot", target_version=">=6")
+        self.compare(source="translated.robot", test_on_version=">=6")
 
     def test_rf6_syntax(self):
-        self.compare(source="rf6.robot", target_version=">=6")
+        self.compare(source="rf6.robot", test_on_version=">=6")

--- a/tests/formatter/formatters/NormalizeTags/test_formatter.py
+++ b/tests/formatter/formatters/NormalizeTags/test_formatter.py
@@ -56,7 +56,7 @@ class TestNormalizeTags(FormatterAcceptanceTest):
         )
 
     def test_rf6(self):
-        self.compare(source="rf6.robot", target_version=">=6", not_modified=True)
+        self.compare(source="rf6.robot", test_on_version=">=6", not_modified=True)
 
     def test_preserve_format(self):
         self.compare(
@@ -78,5 +78,5 @@ class TestNormalizeTags(FormatterAcceptanceTest):
             source="variables_in_tags.robot",
             expected=f"variables_in_tags_{case_function}.robot",
             configure=[f"{self.FORMATTER_NAME}.case={case_function}"],
-            target_version=">=6",
+            test_on_version=">=6",
         )

--- a/tests/formatter/formatters/OrderSettings/test_formatter.py
+++ b/tests/formatter/formatters/OrderSettings/test_formatter.py
@@ -97,7 +97,7 @@ class TestOrderSettings(FormatterAcceptanceTest):
     #     assert result.output == expected_output
 
     def test_translated(self):
-        self.compare(source="translated.robot", target_version=">=6")
+        self.compare(source="translated.robot", test_on_version=">=6")
 
     def test_stick_comments_with_settings(self):
         self.compare(source="stick_comments.robot")

--- a/tests/formatter/formatters/OrderSettingsSection/test_formatter.py
+++ b/tests/formatter/formatters/OrderSettingsSection/test_formatter.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from tests.formatter import FormatterAcceptanceTest
@@ -110,4 +109,4 @@ class TestOrderSettingsSection(FormatterAcceptanceTest):
         self.compare(source="disablers.robot", not_modified=True)
 
     def test_test_tags(self):
-        self.compare(source="test_tags.robot", target_version=">=6")
+        self.compare(source="test_tags.robot", test_on_version=">=6")

--- a/tests/formatter/formatters/OrderTags/test_formatter.py
+++ b/tests/formatter/formatters/OrderTags/test_formatter.py
@@ -67,4 +67,4 @@ class TestOrderTags(FormatterAcceptanceTest):
         self.compare(source="disablers.robot", not_modified=True)
 
     def test_test_tags(self):
-        self.compare(source="test_tags.robot", target_version=">=6")
+        self.compare(source="test_tags.robot", test_on_version=">=6")

--- a/tests/formatter/formatters/RenameVariables/test_formatter.py
+++ b/tests/formatter/formatters/RenameVariables/test_formatter.py
@@ -1,4 +1,3 @@
-
 from tests.formatter import FormatterAcceptanceTest
 
 
@@ -12,10 +11,10 @@ class TestRenameVariables(FormatterAcceptanceTest):
         self.compare(source="test_template.robot")
 
     def test_try_except(self):
-        self.compare(source="try_except.robot", target_version=">=5.0")
+        self.compare(source="try_except.robot", test_on_version=">=5.0")
 
     def test_inline_if(self):
-        self.compare(source="inline_if.robot", target_version=">=5.0")
+        self.compare(source="inline_if.robot", test_on_version=">=5.0")
 
     def test_disablers(self):
         self.compare(source="disablers.robot")
@@ -30,7 +29,7 @@ class TestRenameVariables(FormatterAcceptanceTest):
             source="test.robot",
             expected="test_lower.robot",
             configure=configure,
-            target_version="<6.1",
+            test_on_version="<6.1",
         )
 
     def test_lower_case_rf61(self):
@@ -43,7 +42,7 @@ class TestRenameVariables(FormatterAcceptanceTest):
             source="test.robot",
             expected="test_lower_with_nested.robot",
             configure=configure,
-            target_version=">=6.1",
+            test_on_version=">=6.1",
         )
 
     def test_ignore_unknown_case(self):
@@ -135,7 +134,7 @@ class TestRenameVariables(FormatterAcceptanceTest):
         self.compare(source="math_operations.robot")
 
     def test_var_syntax(self):
-        self.compare(source="VAR_syntax.robot", target_version=">6.1.1")
+        self.compare(source="VAR_syntax.robot", test_on_version=">6.1.1")
 
     def test_equal_sign_in_section(self):
         self.compare(source="equal_sign_in_section.robot")

--- a/tests/formatter/formatters/SplitTooLongLine/test_formatter.py
+++ b/tests/formatter/formatters/SplitTooLongLine/test_formatter.py
@@ -13,7 +13,7 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             expected="feed_until_line_length.robot",
             configure=configure,
             space_count=4,
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_split_too_long_lines_4(self):
@@ -22,7 +22,7 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             source="tests.robot",
             expected="feed_until_line_length_4.robot",
             config=configure,
-            target_version="==4",
+            test_on_version="==4",
         )
 
     def test_split_too_long_lines_split_on_every_arg(self):
@@ -30,7 +30,7 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             source="tests.robot",
             expected="split_on_every_arg.robot",
             configure=[f"{self.FORMATTER_NAME}.line_length=80"],
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_split_too_long_lines_split_on_every_arg_4(self):
@@ -38,7 +38,7 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             source="tests.robot",
             expected="split_on_every_arg_4.robot",
             configure=[f"{self.FORMATTER_NAME}.line_length=80"],
-            target_version="==5",
+            test_on_version="==5",
         )
 
     def test_split_lines_with_multiple_assignments(self):
@@ -67,7 +67,7 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             source="disablers.robot",
             configure=[f"{self.FORMATTER_NAME}.line_length=80"],
             not_modified=True,
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_continuation_indent(self):
@@ -79,7 +79,7 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             space_count=2,
             continuation_indent=4,
             indent=2,
-            target_version=">=5",
+            test_on_version=">=5",
         )
         configure = [f"{self.FORMATTER_NAME}.line_length=80", f"{self.FORMATTER_NAME}.split_on_every_arg=True"]
         self.compare(
@@ -89,7 +89,7 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             space_count=2,
             continuation_indent=4,
             indent=2,
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_variables_split(self):
@@ -118,7 +118,7 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
             source="tests.robot",
             expected="skip_keywords.robot",
             configure=configure,
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_comments(self):
@@ -225,4 +225,4 @@ class TestSplitTooLongLine(FormatterAcceptanceTest):
         )
 
     def test_var_syntax(self):
-        self.compare(source="VAR_syntax.robot", target_version=">=7")
+        self.compare(source="VAR_syntax.robot", test_on_version=">=7")

--- a/tests/formatter/formatters/Translate/test_formatter.py
+++ b/tests/formatter/formatters/Translate/test_formatter.py
@@ -1,4 +1,3 @@
-
 from tests.formatter import FormatterAcceptanceTest
 
 

--- a/tests/linter/rules/comments/invalid_comment/test_rule.py
+++ b/tests/linter/rules/comments/invalid_comment/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version="<4")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version="<4")

--- a/tests/linter/rules/community_rules/keywords/not_allowed_keyword/test_rule.py
+++ b/tests/linter/rules/community_rules/keywords/not_allowed_keyword/test_rule.py
@@ -8,7 +8,7 @@ class TestRuleAcceptance(RuleAcceptance):
             expected_file="expected_output.txt",
             configure=["not-allowed-keyword.keywords=NotAllowed,Not_AllowedWithArgs,library.not_allowed_with_lib"],
             issue_format="end_col",
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_rule_rf3(self):
@@ -17,7 +17,7 @@ class TestRuleAcceptance(RuleAcceptance):
             expected_file="expected_output_rf3.txt",
             configure=["not-allowed-keyword.keywords=NotAllowed,Not_AllowedWithArgs,library.not_allowed_with_lib"],
             issue_format="end_col",
-            target_version="==3.*",
+            test_on_version="==3.*",
         )
 
     def test_rule_rf4(self):
@@ -26,5 +26,5 @@ class TestRuleAcceptance(RuleAcceptance):
             expected_file="expected_output_rf4.txt",
             configure=["not-allowed-keyword.keywords=NotAllowed,Not_AllowedWithArgs,library.not_allowed_with_lib"],
             issue_format="end_col",
-            target_version="==4.*",
+            test_on_version="==4.*",
         )

--- a/tests/linter/rules/duplications/duplicated_library/test_rule.py
+++ b/tests/linter/rules/duplications/duplicated_library/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf6.txt", target_version="<6.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf6.txt", test_on_version="<6.0")
 
     def test_rule_rf6(self):
-        self.check_rule(expected_file="expected_output_rf6.txt", target_version=">=6.0")
+        self.check_rule(expected_file="expected_output_rf6.txt", test_on_version=">=6.0")

--- a/tests/linter/rules/errors/invalid_argument/test_rule.py
+++ b/tests/linter/rules/errors/invalid_argument/test_rule.py
@@ -4,5 +4,5 @@ from tests.linter.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(
-            src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4", issue_format="end_col"
+            src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=4", issue_format="end_col"
         )

--- a/tests/linter/rules/errors/invalid_for_loop/test_rule.py
+++ b/tests/linter/rules/errors/invalid_for_loop/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf5.txt", target_version=">=5")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf5.txt", test_on_version=">=5")
 
     def test_rf4(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version="==4.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version="==4.*")

--- a/tests/linter/rules/errors/invalid_if/test_rule.py
+++ b/tests/linter/rules/errors/invalid_if/test_rule.py
@@ -3,13 +3,13 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf6.1.txt", target_version=">=6.1")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf6.1.txt", test_on_version=">=6.1")
 
     def test_rf6(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf6.txt", target_version="==6.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf6.txt", test_on_version="==6.0")
 
     def test_rf5(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf5.txt", target_version="==5.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf5.txt", test_on_version="==5.*")
 
     def test_rf4(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", target_version="==4.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", test_on_version="==4.*")

--- a/tests/linter/rules/errors/invalid_section_in_resource/test_rule.py
+++ b/tests/linter/rules/errors/invalid_section_in_resource/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", target_version=">=6")
+        self.check_rule(expected_file="expected_output.txt", test_on_version=">=6")
 
     def test_rule_pre6(self):
-        self.check_rule(expected_file="expected_output_pre6.txt", target_version="<6")
+        self.check_rule(expected_file="expected_output_pre6.txt", test_on_version="<6")

--- a/tests/linter/rules/errors/invalid_setting_in_resource/test_rule.py
+++ b/tests/linter/rules/errors/invalid_setting_in_resource/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output_rf6.txt", target_version=">=6")
+        self.check_rule(expected_file="expected_output_rf6.txt", test_on_version=">=6")
 
     def test_rule_pre6(self):
-        self.check_rule(expected_file="expected_output_pre_rf6.txt", target_version="<=5")
+        self.check_rule(expected_file="expected_output_pre_rf6.txt", test_on_version="<=5")

--- a/tests/linter/rules/errors/not_enough_whitespace_after_variable/test_rule.py
+++ b/tests/linter/rules/errors/not_enough_whitespace_after_variable/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=4")

--- a/tests/linter/rules/errors/parsing_error/test_rule.py
+++ b/tests/linter/rules/errors/parsing_error/test_rule.py
@@ -3,19 +3,19 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRule(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output_rf7.txt", target_version=">=7")
+        self.check_rule(expected_file="expected_output_rf7.txt", test_on_version=">=7")
 
     def test_rule_rf61(self):
-        self.check_rule(expected_file="expected_output.txt", target_version="==6.1.*")
+        self.check_rule(expected_file="expected_output.txt", test_on_version="==6.1.*")
 
     def test_rule_rf6(self):
-        self.check_rule(expected_file="expected_output_rf6.txt", target_version="==6.0")
+        self.check_rule(expected_file="expected_output_rf6.txt", test_on_version="==6.0")
 
     def test_rule_rf5(self):
-        self.check_rule(expected_file="expected_output_rf5.txt", target_version="==5.*")
+        self.check_rule(expected_file="expected_output_rf5.txt", test_on_version="==5.*")
 
     def test_rule_rf4(self):
-        self.check_rule(expected_file="expected_output_rf4.txt", target_version="==4.1.3")
+        self.check_rule(expected_file="expected_output_rf4.txt", test_on_version="==4.1.3")
 
     def test_rule_rf3(self):
-        self.check_rule(expected_file="expected_output_rf3.txt", target_version="==3.2.2")
+        self.check_rule(expected_file="expected_output_rf3.txt", test_on_version="==3.2.2")

--- a/tests/linter/rules/errors/return_in_test_case/test_rule.py
+++ b/tests/linter/rules/errors/return_in_test_case/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=5")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5")

--- a/tests/linter/rules/errors/setting_not_supported/test_rule.py
+++ b/tests/linter/rules/errors/setting_not_supported/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=[">=7.0"])
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=[">=7.0"])
 
     def test_pre_rf7(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre7.txt", target_version="<7.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre7.txt", test_on_version="<7.0")

--- a/tests/linter/rules/errors/unsupported_setting_in_init_file/test_rule.py
+++ b/tests/linter/rules/errors/unsupported_setting_in_init_file/test_rule.py
@@ -14,5 +14,5 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["pl_language/__init__.robot", "pl_language/__init__.resource", "pl_language/test.robot"],
             expected_file="pl_language/expected_output.txt",
             issue_format="end_col",
-            target_version=">=6",
+            test_on_version=">=6",
         )

--- a/tests/linter/rules/lengths/empty_keyword_tags/test_rule.py
+++ b/tests/linter/rules/lengths/empty_keyword_tags/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=6.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=6.0")

--- a/tests/linter/rules/lengths/number_of_returned_values/test_rule.py
+++ b/tests/linter/rules/lengths/number_of_returned_values/test_rule.py
@@ -3,17 +3,17 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=5.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5.0")
 
     def test_rule_pre_rf5(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf5.txt", target_version="<5.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf5.txt", test_on_version="<5.0")
 
     def test_severity_threshold(self):
         self.check_rule(
             configure=["number-of-returned-values.severity_threshold=error=6"],
             src_files=["severity.robot"],
             expected_file="expected_output_severity_threshold_rf5.txt",
-            target_version=">=5.0",
+            test_on_version=">=5.0",
         )
 
     def test_severity_threshold_pre_rf5(self):
@@ -21,5 +21,5 @@ class TestRuleAcceptance(RuleAcceptance):
             configure=["number-of-returned-values.severity_threshold=error=6"],
             src_files=["severity.robot"],
             expected_file="expected_output_severity_threshold.txt",
-            target_version="<5.0",
+            test_on_version="<5.0",
         )

--- a/tests/linter/rules/lengths/too_few_calls_in_keyword/test_rule.py
+++ b/tests/linter/rules/lengths/too_few_calls_in_keyword/test_rule.py
@@ -13,7 +13,7 @@ class TestRuleAcceptance(RuleAcceptance):
             ],
             src_files=["bug629.robot"],
             expected_file="expected_output_bug629_rf3.txt",
-            target_version="==3.2.2",
+            test_on_version="==3.2.2",
         )
 
     def test_bug629_rf4(self):
@@ -24,7 +24,7 @@ class TestRuleAcceptance(RuleAcceptance):
             ],
             src_files=["bug629.robot"],
             expected_file="expected_output_bug629_rf4.txt",
-            target_version="==4.1.3",
+            test_on_version="==4.1.3",
         )
 
     def test_bug629(self):
@@ -35,7 +35,7 @@ class TestRuleAcceptance(RuleAcceptance):
             ],
             src_files=["bug629.robot"],
             expected_file="expected_output_bug629.txt",
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_severity_threshold(self):

--- a/tests/linter/rules/misc/argument_overwritten_before_usage/test_rule.py
+++ b/tests/linter/rules/misc/argument_overwritten_before_usage/test_rule.py
@@ -7,7 +7,7 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot"],
             expected_file="expected_output_after_var.txt",
             issue_format="end_col",
-            target_version=">=7",
+            test_on_version=">=7",
         )
 
     def test_rule_pre_var(self):
@@ -15,7 +15,7 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot"],
             expected_file="expected_output_pre_var.txt",
             issue_format="end_col",
-            target_version=">=5;<7",
+            test_on_version=">=5;<7",
         )
 
     def test_rule_rf3_rf4(self):
@@ -23,7 +23,7 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot"],
             expected_file="expected_output_rf3.txt",
             issue_format="end_col",
-            target_version="<5",
+            test_on_version="<5",
         )
 
     def test_rule_arguments_should_clear_after_keyword(self):

--- a/tests/linter/rules/misc/empty_variable/test_rule.py
+++ b/tests/linter/rules/misc/empty_variable/test_rule.py
@@ -3,14 +3,14 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=7")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=7")
 
     def test_rule_only_var(self):
         self.check_rule(
             src_files=["test.robot"],
             expected_file="expected_output_var.txt",
             configure=["empty-variable.variable_source=var"],
-            target_version=">=7",
+            test_on_version=">=7",
         )
 
     def test_rule_only_var_section(self):
@@ -18,8 +18,8 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot"],
             expected_file="expected_output_pre_var.txt",
             configure=["empty-variable.variable_source=section"],
-            target_version=">=7",
+            test_on_version=">=7",
         )
 
     def test_rule_pre_var(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_var.txt", target_version="<7")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_var.txt", test_on_version="<7")

--- a/tests/linter/rules/misc/expression_can_be_simplified/test_rule.py
+++ b/tests/linter/rules/misc/expression_can_be_simplified/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule_rf4(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", target_version="==4.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", test_on_version="==4.*")
 
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=5")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5")

--- a/tests/linter/rules/misc/if_can_be_merged/test_rule.py
+++ b/tests/linter/rules/misc/if_can_be_merged/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", target_version=">=5.0")
+        self.check_rule(expected_file="expected_output.txt", test_on_version=">=5.0")
 
     def test_rule_rf4(self):
-        self.check_rule(expected_file="expected_output_rf4.txt", target_version="==4.*")
+        self.check_rule(expected_file="expected_output_rf4.txt", test_on_version="==4.*")

--- a/tests/linter/rules/misc/if_can_be_used/test_rule.py
+++ b/tests/linter/rules/misc/if_can_be_used/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version="==4")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version="==4")

--- a/tests/linter/rules/misc/inline_if_can_be_used/test_rule.py
+++ b/tests/linter/rules/misc/inline_if_can_be_used/test_rule.py
@@ -3,12 +3,12 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=5.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5.0")
 
     def test_severity_threshold(self):
         self.check_rule(
             configure=["inline-if-can-be-used.severity_threshold=warning=40"],
             src_files=["severity.robot"],
             expected_file="expected_output_severity.txt",
-            target_version=">=5.0",
+            test_on_version=">=5.0",
         )

--- a/tests/linter/rules/misc/keyword_section_out_of_order/test_rule.py
+++ b/tests/linter/rules/misc/keyword_section_out_of_order/test_rule.py
@@ -9,7 +9,7 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(
             src_files=["test.robot", "test_kw_setup_added_in_rf7.robot"],
             expected_file="expected_output_rf7.txt",
-            target_version=">=7",
+            test_on_version=">=7",
         )
 
     def test_rule_teardown_keyword(self):

--- a/tests/linter/rules/misc/misplaced_negative_condition/test_rule.py
+++ b/tests/linter/rules/misc/misplaced_negative_condition/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule_rf4(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", target_version="==4.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", test_on_version="==4.*")
 
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=5")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5")

--- a/tests/linter/rules/misc/multiline_inline_if/test_rule.py
+++ b/tests/linter/rules/misc/multiline_inline_if/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", target_version=">=5.0")
+        self.check_rule(expected_file="expected_output.txt", test_on_version=">=5.0")

--- a/tests/linter/rules/misc/nested_for_loop/test_rule.py
+++ b/tests/linter/rules/misc/nested_for_loop/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version="<4.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version="<4.0")

--- a/tests/linter/rules/misc/statement_outside_loop/test_rule.py
+++ b/tests/linter/rules/misc/statement_outside_loop/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=5.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5.0")

--- a/tests/linter/rules/misc/unreachable_code/test_rule.py
+++ b/tests/linter/rules/misc/unreachable_code/test_rule.py
@@ -5,5 +5,5 @@ class TestRuleAcceptance(RuleAcceptance):
     def test_rule_before(self):
         self.check_rule(
             expected_file="expected_output.txt",
-            target_version=">=5.0",
+            test_on_version=">=5.0",
         )

--- a/tests/linter/rules/misc/unused_argument/test_rule.py
+++ b/tests/linter/rules/misc/unused_argument/test_rule.py
@@ -4,11 +4,11 @@ from tests.linter.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(
-            src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=5", issue_format="end_col"
+            src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=5", issue_format="end_col"
         )
 
     def test_rule_rf3(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", target_version="==3.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", test_on_version="==3.*")
 
     def test_rule_rf4(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", target_version="==4.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", test_on_version="==4.*")

--- a/tests/linter/rules/misc/unused_variable/test_rule.py
+++ b/tests/linter/rules/misc/unused_variable/test_rule.py
@@ -7,7 +7,7 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot", "unused_section_vars.robot"],
             expected_file="expected_output_after_var.txt",
             issue_format="end_col",
-            target_version=">=7",
+            test_on_version=">=7",
         )
 
     def test_rule_pre_var(self):
@@ -15,7 +15,7 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot", "unused_section_vars.robot"],
             expected_file="expected_output_pre_var.txt",
             issue_format="end_col",
-            target_version=">=4;<7",
+            test_on_version=">=4;<7",
         )
 
     def test_rule_rf3(self):
@@ -23,7 +23,7 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot", "unused_section_vars.robot"],
             expected_file="expected_output_rf3.txt",
             issue_format="end_col",
-            target_version="==3.*",
+            test_on_version="==3.*",
         )
 
     def test_rule_on_loops(self):
@@ -31,5 +31,5 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["loops.robot"],
             expected_file="expected_output_loops.txt",
             issue_format="end_col",
-            target_version=">=5",
+            test_on_version=">=5",
         )

--- a/tests/linter/rules/misc/variable_overwritten_before_usage/test_rule.py
+++ b/tests/linter/rules/misc/variable_overwritten_before_usage/test_rule.py
@@ -3,21 +3,21 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule_after_var(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_after_var.txt", target_version=">=7")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_after_var.txt", test_on_version=">=7")
 
     def test_rule_pre_var(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_var.txt", target_version=">=4;<7")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_var.txt", test_on_version=">=4;<7")
 
     def test_rule_rf3(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", target_version="==3.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", test_on_version="==3.*")
 
     def test_rule_on_loops(self):
         self.check_rule(
             src_files=["loops.robot"],
             expected_file="expected_output_loops.txt",
             issue_format="end_col",
-            target_version=">=5",
+            test_on_version=">=5",
         )
 
     def test_rule_inline_if(self):
-        self.check_rule(src_files=["inline_if.robot"], expected_file=None, target_version=">=4")
+        self.check_rule(src_files=["inline_if.robot"], expected_file=None, test_on_version=">=4")

--- a/tests/linter/rules/naming/deprecated_singular_header/test_rule.py
+++ b/tests/linter/rules/naming/deprecated_singular_header/test_rule.py
@@ -3,10 +3,10 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=6.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=6.0")
 
     def test_language(self):
-        self.check_rule(src_files=["language.robot"], expected_file=None, target_version=">=6.0", language=["pl"])
+        self.check_rule(src_files=["language.robot"], expected_file=None, test_on_version=">=6.0", language=["pl"])
 
     def test_pre_rf5(self):
-        self.check_rule(src_files=["test.robot"], expected_file=None, target_version="<5.0")
+        self.check_rule(src_files=["test.robot"], expected_file=None, test_on_version="<5.0")

--- a/tests/linter/rules/naming/deprecated_statement/test_rule.py
+++ b/tests/linter/rules/naming/deprecated_statement/test_rule.py
@@ -6,20 +6,20 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(
             src_files=["test.robot", "templated_suite.robot"],
             expected_file="expected_output_rf6.txt",
-            target_version=">=6",
+            test_on_version=">=6",
         )
 
     def test_rule_rf5(self):
         self.check_rule(
             src_files=["test.robot", "templated_suite.robot"],
             expected_file="expected_output_rf5.txt",
-            target_version="==5.*",
+            test_on_version="==5.*",
         )
 
     def test_pre_rf5(self):
-        self.check_rule(src_files=["test.robot", "templated_suite.robot"], expected_file=None, target_version="<5.0")
+        self.check_rule(src_files=["test.robot", "templated_suite.robot"], expected_file=None, test_on_version="<5.0")
 
     def test_force_tags(self):
         self.check_rule(
-            src_files=["force_tags.robot"], expected_file="expected_output_force_tags.txt", target_version=">=6"
+            src_files=["force_tags.robot"], expected_file="expected_output_force_tags.txt", test_on_version=">=6"
         )

--- a/tests/linter/rules/naming/deprecated_with_name/test_rule.py
+++ b/tests/linter/rules/naming/deprecated_with_name/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=6.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=6.0")

--- a/tests/linter/rules/naming/duplicated_library_alias/test_rule.py
+++ b/tests/linter/rules/naming/duplicated_library_alias/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf6_0.txt", target_version=">=6.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf6_0.txt", test_on_version=">=6.0")
 
     def test_pre_rf6(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf6_0.txt", target_version="<6.0")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf6_0.txt", test_on_version="<6.0")

--- a/tests/linter/rules/naming/else_not_upper_case/test_rule.py
+++ b/tests/linter/rules/naming/else_not_upper_case/test_rule.py
@@ -3,10 +3,10 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf5.txt", target_version=">=5")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf5.txt", test_on_version=">=5")
 
     def test_rf_4(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", target_version="==4.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf4.txt", test_on_version="==4.*")
 
     def test_rf_3(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", target_version="==3.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", test_on_version="==3.*")

--- a/tests/linter/rules/naming/empty_library_alias/test_rule.py
+++ b/tests/linter/rules/naming/empty_library_alias/test_rule.py
@@ -3,7 +3,7 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=6")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=6")
 
     def test_pre_rf6(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf6.txt", target_version="<6")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre_rf6.txt", test_on_version="<6")

--- a/tests/linter/rules/naming/hyphen_in_variable_name/test_rule.py
+++ b/tests/linter/rules/naming/hyphen_in_variable_name/test_rule.py
@@ -6,4 +6,4 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
 
     def test_var_syntax(self):
-        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", target_version=">=7")
+        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", test_on_version=">=7")

--- a/tests/linter/rules/naming/inconsistent_variable_name/test_rule.py
+++ b/tests/linter/rules/naming/inconsistent_variable_name/test_rule.py
@@ -4,7 +4,7 @@ from tests.linter.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule_pre(self):
         self.check_rule(
-            src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col", target_version=">=7"
+            src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col", test_on_version=">=7"
         )
 
     def test_rule_pre_rf7(self):
@@ -12,5 +12,5 @@ class TestRuleAcceptance(RuleAcceptance):
             src_files=["test.robot"],
             expected_file="expected_output_pre_7.txt",
             issue_format="end_col",
-            target_version="<7",
+            test_on_version="<7",
         )

--- a/tests/linter/rules/naming/invalid_section/test_rule.py
+++ b/tests/linter/rules/naming/invalid_section/test_rule.py
@@ -4,5 +4,5 @@ from tests.linter.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(
-            src_files=["test.robot", "test_lang.resource"], expected_file="expected_output.txt", target_version=">=6.1"
+            src_files=["test.robot", "test_lang.resource"], expected_file="expected_output.txt", test_on_version=">=6.1"
         )

--- a/tests/linter/rules/naming/keyword_name_is_reserved_word/test_rule.py
+++ b/tests/linter/rules/naming/keyword_name_is_reserved_word/test_rule.py
@@ -3,10 +3,10 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output_rf5.txt", target_version=">=5")
+        self.check_rule(expected_file="expected_output_rf5.txt", test_on_version=">=5")
 
     def test_rf4(self):
-        self.check_rule(expected_file="expected_output_rf4.txt", target_version="==4.*")
+        self.check_rule(expected_file="expected_output_rf4.txt", test_on_version="==4.*")
 
     def test_rf3(self):
-        self.check_rule(expected_file="expected_output_rf3.txt", target_version="==3.*")
+        self.check_rule(expected_file="expected_output_rf3.txt", test_on_version="==3.*")

--- a/tests/linter/rules/naming/mixed_task_test_settings/test_rule.py
+++ b/tests/linter/rules/naming/mixed_task_test_settings/test_rule.py
@@ -14,7 +14,7 @@ class TestRuleAcceptance(RuleAcceptance):
                 "__init__.robot",
             ],
             expected_file="expected_output_rf6.txt",
-            target_version=">=6",
+            test_on_version=">=6",
         )
 
     def test_rule(self):
@@ -29,5 +29,5 @@ class TestRuleAcceptance(RuleAcceptance):
                 "__init__.robot",
             ],
             expected_file="expected_output_pre_rf6.txt",
-            target_version="<6",
+            test_on_version="<6",
         )

--- a/tests/linter/rules/naming/non_local_variables_should_be_uppercase/test_rule.py
+++ b/tests/linter/rules/naming/non_local_variables_should_be_uppercase/test_rule.py
@@ -6,4 +6,4 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt")
 
     def test_var(self):
-        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", target_version=">=7")
+        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", test_on_version=">=7")

--- a/tests/linter/rules/naming/overwriting_reserved_variable/test_rule.py
+++ b/tests/linter/rules/naming/overwriting_reserved_variable/test_rule.py
@@ -6,4 +6,4 @@ class TestRuleAcceptance(RuleAcceptance):
         self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col")
 
     def test_var(self):
-        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", target_version=">=7")
+        self.check_rule(src_files=["VAR_syntax.robot"], expected_file="expected_output_var.txt", test_on_version=">=7")

--- a/tests/linter/rules/naming/possible_variable_overwriting/test_rule.py
+++ b/tests/linter/rules/naming/possible_variable_overwriting/test_rule.py
@@ -3,17 +3,17 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=7")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=7")
 
     def test_rule_pre_rf7(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre7.txt", target_version=">=6.1;<7")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_pre7.txt", test_on_version=">=6.1;<7")
 
     def test_pre_rf6_1(self):
         self.check_rule(
             src_files=["test.robot"],
             expected_file="expected_output_pre6.1.txt",
-            target_version=["==4.*", "==5.*", "==6.0"],
+            test_on_version=["==4.*", "==5.*", "==6.0"],
         )
 
     def test_rf3(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", target_version="==3.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", test_on_version="==3.*")

--- a/tests/linter/rules/naming/replace_create_with_var/test_rule.py
+++ b/tests/linter/rules/naming/replace_create_with_var/test_rule.py
@@ -4,5 +4,5 @@ from tests.linter.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(
-            src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col", target_version=">=7"
+            src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col", test_on_version=">=7"
         )

--- a/tests/linter/rules/naming/replace_set_variable_with_var/test_rule.py
+++ b/tests/linter/rules/naming/replace_set_variable_with_var/test_rule.py
@@ -4,5 +4,5 @@ from tests.linter.utils import RuleAcceptance
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
         self.check_rule(
-            src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col", target_version=">=7"
+            src_files=["test.robot"], expected_file="expected_output.txt", issue_format="end_col", test_on_version=">=7"
         )

--- a/tests/linter/rules/naming/section_variable_not_uppercase/test_rule.py
+++ b/tests/linter/rules/naming/section_variable_not_uppercase/test_rule.py
@@ -3,8 +3,8 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=4")
 
     def test_rule_rf3(self):
         # RF3 doesn't recognize nested variables in Variables section
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", target_version="==3.*")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output_rf3.txt", test_on_version="==3.*")

--- a/tests/linter/rules/spacing/bad_block_indent/test_rule.py
+++ b/tests/linter/rules/spacing/bad_block_indent/test_rule.py
@@ -4,9 +4,9 @@ from tests.linter.utils import RuleAcceptance
 
 
 class TestRuleAcceptance(RuleAcceptance):
-    @pytest.mark.parametrize(("file_suffix", "target_version"), [("", ">=5"), ("_rf4", "==4.*"), ("_rf3", "==3.*")])
-    def test_rule(self, file_suffix, target_version):
+    @pytest.mark.parametrize(("file_suffix", "test_on_version"), [("", ">=5"), ("_rf4", "==4.*"), ("_rf3", "==3.*")])
+    def test_rule(self, file_suffix, test_on_version):
         self.check_rule(
             expected_file=f"expected_output{file_suffix}.txt",
-            target_version=target_version,
+            test_on_version=test_on_version,
         )

--- a/tests/linter/rules/spacing/bad_indent/test_rule.py
+++ b/tests/linter/rules/spacing/bad_indent/test_rule.py
@@ -8,22 +8,22 @@ class TestRuleAcceptance(RuleAcceptance):
     def test_templated_suite(self, config):
         self.check_rule(configure=config, src_files=["templated_suite.robot"], expected_file=None)
 
-    @pytest.mark.parametrize(("file_suffix", "target_version"), [("", ">=5"), ("_rf4", "==4.*"), ("_rf3", "==3.*")])
-    def test_strict_3_spaces(self, file_suffix, target_version):
+    @pytest.mark.parametrize(("file_suffix", "test_on_version"), [("", ">=5"), ("_rf4", "==4.*"), ("_rf3", "==3.*")])
+    def test_strict_3_spaces(self, file_suffix, test_on_version):
         self.check_rule(
             configure=["bad-indent.indent=3"],
             src_files=["bug375.robot", "comments.robot", "test.robot"],
             expected_file=f"indent_3spaces/expected_output{file_suffix}.txt",
-            target_version=target_version,
+            test_on_version=test_on_version,
         )
 
-    @pytest.mark.parametrize(("file_suffix", "target_version"), [("", ">=5"), ("_rf4", "==4.*"), ("_rf3", "==3.*")])
-    def test_rule(self, file_suffix, target_version):
+    @pytest.mark.parametrize(("file_suffix", "test_on_version"), [("", ">=5"), ("_rf4", "==4.*"), ("_rf3", "==3.*")])
+    def test_rule(self, file_suffix, test_on_version):
         self.check_rule(
             configure=["bad-indent.indent=-1"],
             src_files=["bug375.robot", "comments.robot", "test.robot"],
             expected_file=f"expected_output{file_suffix}.txt",
-            target_version=target_version,
+            test_on_version=test_on_version,
         )
 
     def test_758_bug(self):

--- a/tests/linter/rules/spacing/suite_setting_should_be_left_aligned/test_rule.py
+++ b/tests/linter/rules/spacing/suite_setting_should_be_left_aligned/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", target_version=">=4")
+        self.check_rule(expected_file="expected_output.txt", test_on_version=">=4")

--- a/tests/linter/rules/spacing/variable_should_be_left_aligned/test_rule.py
+++ b/tests/linter/rules/spacing/variable_should_be_left_aligned/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", target_version=">=4")
+        self.check_rule(src_files=["test.robot"], expected_file="expected_output.txt", test_on_version=">=4")

--- a/tests/linter/rules/tags/could_be_keyword_tags/test_rule.py
+++ b/tests/linter/rules/tags/could_be_keyword_tags/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", target_version=">=6")
+        self.check_rule(expected_file="expected_output.txt", test_on_version=">=6")

--- a/tests/linter/rules/tags/could_be_test_tags/test_rule.py
+++ b/tests/linter/rules/tags/could_be_test_tags/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", target_version=">=6")
+        self.check_rule(expected_file="expected_output.txt", test_on_version=">=6")

--- a/tests/linter/rules/tags/tag_already_set_in_keyword_tags/test_rule.py
+++ b/tests/linter/rules/tags/tag_already_set_in_keyword_tags/test_rule.py
@@ -3,4 +3,4 @@ from tests.linter.utils import RuleAcceptance
 
 class TestRuleAcceptance(RuleAcceptance):
     def test_rule(self):
-        self.check_rule(expected_file="expected_output.txt", target_version=">=6")
+        self.check_rule(expected_file="expected_output.txt", test_on_version=">=6")

--- a/tests/linter/rules/tags/tag_already_set_in_test_tags/test_rule.py
+++ b/tests/linter/rules/tags/tag_already_set_in_test_tags/test_rule.py
@@ -7,5 +7,5 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_test_tags(self):
         self.check_rule(
-            src_files=["test_tags.robot"], expected_file="expected_output_test_tags.txt", target_version=">=6"
+            src_files=["test_tags.robot"], expected_file="expected_output_test_tags.txt", test_on_version=">=6"
         )

--- a/tests/linter/rules/tags/tag_with_or_and/test_rule.py
+++ b/tests/linter/rules/tags/tag_with_or_and/test_rule.py
@@ -7,5 +7,5 @@ class TestRuleAcceptance(RuleAcceptance):
 
     def test_keyword_tags(self):
         self.check_rule(
-            src_files=["keyword_tags.robot"], expected_file="expected_output_keyword_tags.txt", target_version=">=6"
+            src_files=["keyword_tags.robot"], expected_file="expected_output_keyword_tags.txt", test_on_version=">=6"
         )

--- a/tests/linter/utils/__init__.py
+++ b/tests/linter/utils/__init__.py
@@ -73,14 +73,14 @@ class RuleAcceptance:
         threshold: RuleSeverity | None = None,
         select: list[str] | None = None,
         src_files: list | None = None,
-        target_version: str | list[str] | None = None,
+        test_on_version: str | list[str] | None = None,
         issue_format: str = "default",
         language: list[str] | None = None,
         deprecated: bool = False,
         **kwargs,
     ):
-        if not self.enabled_in_version(target_version):
-            pytest.skip(f"Test enabled only for RF {target_version}")
+        if not self.enabled_in_version(test_on_version):
+            pytest.skip(f"Test enabled only for RF {test_on_version}")
         test_data = self.test_class_dir
         expected = load_expected_file(test_data, expected_file)
         issue_format = self.get_issue_format(issue_format)
@@ -141,7 +141,7 @@ class RuleAcceptance:
         return robocop_rules[self.rule_name].enabled_in_version
 
     @staticmethod
-    def enabled_in_version(target_version: list | str | None):
+    def enabled_in_version(test_on_version: list | str | None):
         """
         Check if rule is enabled for given target version condition.
 
@@ -150,11 +150,11 @@ class RuleAcceptance:
         that should match RF version.
         If the target version is a list of strings, any version conditions need to match.
         """
-        if target_version is None:
+        if test_on_version is None:
             return True
-        if isinstance(target_version, list):
-            return any(ROBOT_VERSION in VersionSpecifier(version) for version in target_version)
-        if ";" in target_version:
-            must_match_versions = target_version.split(";")
+        if isinstance(test_on_version, list):
+            return any(ROBOT_VERSION in VersionSpecifier(version) for version in test_on_version)
+        if ";" in test_on_version:
+            must_match_versions = test_on_version.split(";")
             return all(ROBOT_VERSION in VersionSpecifier(version) for version in must_match_versions)
-        return ROBOT_VERSION in VersionSpecifier(target_version)
+        return ROBOT_VERSION in VersionSpecifier(test_on_version)


### PR DESCRIPTION
Re-integrated ``--target-version`` option back to the tool.

Our test framework also used ``target_version`` to filter out which tests to run - it is now replaced by ``test_on_version`` to avoid confusion.