### PR TITLE
Populate documentation from the dynamic groups

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,9 +4,10 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).parent.parent))
+sys.path.append(str(Path(__file__).parent.parent.parent))
 import robocop
 from robocop.linter.rules import SeverityThreshold
+from docs.source.rules_metadata import GROUPS_LOOKUP
 
 # -- Project information -----------------------------------------------------
 
@@ -46,9 +47,9 @@ html_theme_options = {
             "class": "",
         },
     ],
-#     "light_css_variables": {
-#     "color-code-background": "#f8f8f8",
-# }
+    #     "light_css_variables": {
+    #     "color-code-background": "#f8f8f8",
+    # }
 }
 html_static_path = ["images", "_static"]
 html_favicon = "images/robocop.ico"
@@ -69,15 +70,22 @@ def setup(app):
     app.add_css_file("css/custom.css")
 
 
-def get_checker_docs():
+def get_checker_docs() -> tuple[list[tuple], int]:
     """Load rules for dynamic docs generation"""
     checker_docs = defaultdict(list)
     rules = robocop.linter.rules.get_builtin_rules()
-    for module_name, rule in rules:
-        title_name = module_name.title()
+    rules_count = 0
+    for _, rule in rules:
+        rules_count += 1
         severity_threshold = rule.config.get("severity_threshold", None)
         robocop_version = rule.added_in_version if rule.added_in_version else "\\-"
-        checker_docs[title_name].append(
+        match = re.match("(?P<group>.+)(?P<rule_no>[0-9]{2,})", rule.rule_id)
+        group_id = match.group("group")
+        try:
+            group = GROUPS_LOOKUP[group_id]
+        except KeyError:
+            raise ValueError(f"Missing group metadata in rules_metadata.py for {group_id}.")
+        group.rules.append(
             {
                 "name": rule.name,
                 "id": rule.rule_id,
@@ -86,7 +94,7 @@ def get_checker_docs():
                 "version": rule.supported_version,
                 "robocop_version": robocop_version,
                 "msg": rule.message,
-                "docs":rule.docs,
+                "docs": rule.docs,
                 "deprecated": rule.deprecated,
                 "params": [
                     {
@@ -101,16 +109,16 @@ def get_checker_docs():
                 "severity_threshold": severity_threshold,
             }
         )
-    groups_sorted_by_id = []
-    for module_name in checker_docs:
-        sorted_rules = sorted(checker_docs[module_name], key=lambda x: x["id"])
-        match = re.match("(?P<group>.+)(?P<rule_no>[0-9]{2,})", sorted_rules[0]["id"])
-        group_id = match.group("group")
-        groups_sorted_by_id.append((module_name, sorted_rules, group_id))
-    return sorted(groups_sorted_by_id, key=lambda x: x[2])
+    sorted_groups = []
+    for group in GROUPS_LOOKUP.values():
+        group.rules = sorted(group.rules, key=lambda x: x["id"])
+        sorted_groups.append(group)
+    return sorted_groups, rules_count
 
 
-html_context = {"builtin_checkers": get_checker_docs()}
+rule_metadata, rules_count = get_checker_docs()
+rules_length_in_10 = (rules_count // 10) * 10
+html_context = {"builtin_checkers": rule_metadata, "rules_length_in_10": rules_length_in_10}
 
 
 if __name__ == "__main__":

--- a/docs/source/rules_list.rst
+++ b/docs/source/rules_list.rst
@@ -7,18 +7,11 @@ Rules list
 This is the complete list of all Robocop rules grouped by categories.
 If you want to learn more about the rules and their features, see :ref:`rules`.
 
-There are over a 160 rules available in Robocop and they are organized into the following categories:
+There are over a {{ rules_length_in_10 }} rules available in Robocop and they are organized into the following categories:
 
-# TODO
-* 02: :ref:`Documentation`
-* 03: :ref:`Naming`
-* 04: :ref:`Errors`
-* 05: :ref:`Lengths`
-* 06: :ref:`Tags`
-* 07: :ref:`Comments`
-* 08: :ref:`Duplications`
-* 09: :ref:`Misc`
-* 10: :ref:`Spacing`
+{% for group in builtin_checkers %}
+* {{ group.group_id }}: :ref:`{{ group.group_name }}`
+{%- endfor %}
 
 Each rule has a unique rule id consisting of:
 
@@ -27,17 +20,19 @@ Each rule has a unique rule id consisting of:
 
 Below is the list of all built-in Robocop rules.
 
-{% for checker_group in builtin_checkers %}
-.. _{{ checker_group[0] }}:
+{% for group in builtin_checkers %}
+.. _{{ group.group_name }}:
 
-{{ checker_group[0] }}
+{{ group.group_name }}
 ----------------------
-{% for rule_doc in checker_group[1] %}
+
+{{ group.group_docs }}
+{% for rule_doc in group.rules %}
 .. _{{ rule_doc.name }}:
 
 
-{{ rule_doc.name }} / {{ rule_doc.severity }}{{ rule_doc.id }}
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+{{ rule_doc.id }}: {{ rule_doc.name }}
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 {% if rule_doc.deprecated %}
 .. warning::

--- a/docs/source/rules_metadata.py
+++ b/docs/source/rules_metadata.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class RulesGroup:
+    """
+    Class retaining metadata for group and its rules.
+    """
+
+    group_id: str
+    group_name: str
+    group_docs: str
+    rules: list[dict] = field(default_factory=list)
+
+
+GROUPS_LOOKUP = {
+    "ARG": RulesGroup("ARG", "Arguments", "Rules for keyword arguments."),
+    "COM": RulesGroup("COM", "Comments", "Rules for comments."),
+    "DEPR": RulesGroup("DEPR", "Deprecated code", "Rules for deprecated code or code replacement recommendations."),
+    "DOC": RulesGroup("DOC", "Documentation", "Rules for documentation."),
+    "DUP": RulesGroup("DUP", "Duplications", "Rules for duplicated code such as settings or variables."),
+    "ERR": RulesGroup("ERR", "Errors", "Rules for syntax errors and critical issues with the code."),
+    "IMP": RulesGroup("IMP", "Imports", "Rules for resources, variables and libraries imports."),
+    "KW": RulesGroup("KW", "Keywords", "Rules for keywords."),
+    "LEN": RulesGroup("LEN", "Lengths", "Rules for lengths, such as length of the test case or the file."),
+    "MISC": RulesGroup("MISC", "Miscellaneous", "Miscellaneous rules."),
+    "NAME": RulesGroup("NAME", "Naming", "Naming rules."),
+    "ORD": RulesGroup("ORD", "Order", "Ordering rules."),
+    "SPC": RulesGroup("SPC", "Spacing", "Spacing and whitespace related rules."),
+    "TAG": RulesGroup("TAG", "Tags", "Rules for  tags."),
+    "VAR": RulesGroup("VAR", "Variables", "Rules for variables."),
+}


### PR DESCRIPTION
Group names are not hardcoded anymore - but we need to fill each group metadata. If Robocop finds new group without metadata in the docs, it will raise an error.