### PR TITLE
Docs: rewrite configuration examples to include both cli/toml examples

### DIFF
--- a/docs/source/rule_basics.rst
+++ b/docs/source/rule_basics.rst
@@ -78,15 +78,15 @@ Severity threshold
 
 Selected rules can be configured to have different severity depending on the parameter value.
 
-Using ``line-too-long`` as an example - this rule issues a warning when line length exceeds
-configured value (default ``120``).
-It is possible to configure this rule to issue a warning for line length above 120
-but an error for line length above 200.
+Using ``line-too-long`` as an example - this rule issues a warning when line length exceeds configured value
+(default ``120``).
+It is possible to configure this rule to issue a warning for line length above 120 but an error for line length
+above 200.
 We can use ``severity_threshold`` for this purpose:
 
 .. tab-set::
 
-    .. tab-item:: CLI
+    .. tab-item:: Cli
 
         .. code:: none
 
@@ -110,9 +110,25 @@ It supports all default severity values:
 The issue needs to be raised in order for severity thresholds to be evaluated. That's why the parameter value needs to
 be configured to raise an issue for at least one of our threshold ranges. In previous example, if we want to issue
 info message if the line is longer than 80 characters, we need to configure ``line_length`` parameter
-(default ``120``) to 80 to trigger the rule::
+(default ``120``) to 80 to trigger the rule:
 
-    robocop check -c line-too-long.line_length=80 -c line-too-long.severity_threshold=info=80:warning=120:error=200
+.. tab-set::
+
+    .. tab-item:: Cli
+
+        .. code:: none
+
+            robocop check -c line-too-long.line_length=80 -c line-too-long.severity_threshold=info=80:warning=120:error=200
+
+    .. tab-item:: Configuration file
+
+        .. code:: toml
+
+            [robocop.linter]
+            configure = [
+                "line-too-long.line_length=80",
+                "line-too-long.severity_threshold=info=80:warning=120:error=200"
+            ]
 
 Following rules support ``severity_threshold``:
 
@@ -124,30 +140,92 @@ Following rules support ``severity_threshold``:
 {% endfor %}
 {% endfor %}
 
-.. _including-rules:
+.. _selecting-rules:
 
-Including and excluding rules
-==============================
+Selecting and ignoring rules
+=============================
 
 You can select or ignore particular rules using rule name or id.
 
-To only select and run ``missing-doc-keyword`` rule::
+To only select and run ``missing-doc-keyword`` rule:
 
-    robocop check --select missing-doc-keyword test.robot
+.. tab-set::
 
-To run all rules except ``missing-doc-keyword`` rule::
+    .. tab-item:: Cli
 
-    robocop check --ignore missing-doc-keyword test.robot
+        .. code:: none
 
+            robocop check --select missing-doc-keyword
 
-Robocop supports glob patterns::
+    .. tab-item:: Configuration file
 
-    robocop check --select *doc* test.robot
+        .. code:: toml
+
+            [robocop.linter]
+            select = [
+                "missing-doc-keyword"
+            ]
+
+To run all rules except ``missing-doc-keyword`` rule:
+
+.. tab-set::
+
+    .. tab-item:: Cli
+
+        .. code:: none
+
+            robocop check --ignore missing-doc-keyword
+
+    .. tab-item:: Configuration file
+
+        .. code:: toml
+
+            [robocop.linter]
+            ignore = [
+                "missing-doc-keyword"
+            ]
+
+Robocop supports glob patterns:
+
+.. tab-set::
+
+    .. tab-item:: Cli
+
+        .. code:: none
+
+             robocop check --select *doc*
+
+    .. tab-item:: Configuration file
+
+        .. code:: toml
+
+            [robocop.linter]
+            select = [
+                "*doc*"
+            ]
 
 All rules will be ignored except those with *doc* in its name (like ``missing-doc-keyword``, ``too-long-doc`` etc).
 
-To configure multiple rules you can repeat option / or add more to array (configuration file)::
+To configure multiple rules you can repeat option / or add more to array (configuration file):
 
-    robocop check --select rule1 --select rule2 --select rule3 --ignore rule2 test.robot
+.. tab-set::
 
+    .. tab-item:: Cli
 
+        .. code:: none
+
+             robocop check --select rule1 --select rule2 --select rule3 --ignore rule2
+
+    .. tab-item:: Configuration file
+
+        .. code:: toml
+
+            [robocop.linter]
+            select = [
+                "rule1",
+                "rule2",
+                "rule3"
+            ]
+            ignore = [
+                "rule2"
+            ]

--- a/src/robocop/linter/rules/__init__.py
+++ b/src/robocop/linter/rules/__init__.py
@@ -61,11 +61,30 @@ if TYPE_CHECKING:
 @total_ordering
 class RuleSeverity(Enum):
     """
-    It can be configured with ``--configure id_or_msg_name.severity=value``
-    where value can be first letter of severity value or whole name, case-insensitive.
-    For example ::
+    It can be configured with::
 
-        robocop check -c line-too-long.severity=e
+        robocop check --configure id_or_msg_name.severity=value
+
+    where value can be first letter of severity value or whole name, case-insensitive.
+
+    For example:
+
+    .. tab-set::
+
+        .. tab-item:: Cli
+
+            .. code:: none
+
+                robocop check -c line-too-long.severity=e
+
+        .. tab-item:: Configuration file
+
+            .. code:: toml
+
+                [robocop.linter]
+                configure = [
+                    "line-too-long.severity=e"
+                ]
 
     will change `line-too-long` rule severity to error.
 
@@ -73,9 +92,22 @@ class RuleSeverity(Enum):
 
         robocop check -t <severity value>
 
-    To only report rules with severity W and above::
+    To only report rules with severity W and above:
 
-        robocop check --threshold W
+    .. tab-set::
+
+        .. tab-item:: Cli
+
+            .. code:: none
+
+                robocop check --threshold W
+
+        .. tab-item:: Configuration file
+
+            .. code:: toml
+
+                [robocop.linter]
+                threshold = "W"
 
     """
 

--- a/src/robocop/linter/rules/misc.py
+++ b/src/robocop/linter/rules/misc.py
@@ -163,11 +163,26 @@ class InconsistentAssignmentRule(Rule):
             ${var}  ${var2}    Some Keyword
 
     By default, Robocop looks for most popular assignment sign in the file. It is possible to define expected
-    assignment sign by running::
+    assignment sign by running:
 
-        robocop check --configure inconsistent-assignment.assignment_sign_type=equal_sign
+    .. tab-set::
 
-    You can choose between following signs:
+        .. tab-item:: Cli
+
+            .. code:: none
+
+                robocop check --configure inconsistent-assignment.assignment_sign_type=none
+
+        .. tab-item:: Configuration file
+
+            .. code:: toml
+
+                [robocop.linter]
+                configure = [
+                    "inconsistent-assignment.assignment_sign_type=none"
+                ]
+
+    You can choose between following assignment signs:
 
     - 'autodetect' (default),
     - 'none',
@@ -704,7 +719,7 @@ class ConsistentAssignmentSignChecker(VisitorChecker):
     section and ``*** Test Cases ***``, ``*** Keywords ***`` sections) and report any inconsistent type of sign in
     particular file.
 
-    To force one type of sign type you, can configure two rules::
+    To force one type of sign type you can configure two rules::
 
         robocop check --configure inconsistent-assignment.assignment_sign_type={sign_type}
         robocop check --configure inconsistent-assignment-in-variables.assignment_sign_type={sign_type}


### PR DESCRIPTION
To make it easier for users to refer how the configuraton should look like, I started to extend docs examples with toml examples:

![image](https://github.com/user-attachments/assets/7d330ea0-d09f-4c04-a650-50a8a64d9496)

![image](https://github.com/user-attachments/assets/5a2994a2-8704-4547-922f-5a323298f694)
