### PR TITLE
Add linter & formatter documentation

### DIFF
--- a/docs/releasenotes/6.0.0dev1.rst
+++ b/docs/releasenotes/6.0.0dev1.rst
@@ -488,8 +488,8 @@ Order related rules (except imports) are now grouped under 'ORD' group:
 - ``0927`` became ``ORD01`` (``test-case-section-out-of-order``)
 - ``0928`` became ``ORD02`` (``keyword-section-out-of-order``)
 
-New features
-=============
+New features & other changes
+============================
 
 Multiple configuration files
 -----------------------------
@@ -536,6 +536,13 @@ Example output::
 
     tests\linter\rules\tags\tag_already_set_in_test_tags\keyword_tag.robot:
       3:1 0319 'Force Tags' is deprecated since Robot Framework version 6.0, use 'Test Tags' instead (deprecated-statement)
+
+Shell autocompletion
+---------------------
+
+You can now use shell autocompletion by installing it for the current shell::
+
+    robocop --install-completion
 
 Fixes
 =====

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ exclude_patterns = ["**/releasenotes/*"]
 suppress_warnings = ["config.cache"]
 
 html_theme = "furo"
-html_title = f"Robocop {release} documentation"
+html_title = f"Robocop {release}"
 html_logo = "images/robocop_logo_small.png"
 html_theme_options = {
     "footer_icons": [
@@ -47,9 +47,6 @@ html_theme_options = {
             "class": "",
         },
     ],
-    #     "light_css_variables": {
-    #     "color-code-background": "#f8f8f8",
-    # }
 }
 html_static_path = ["images", "_static"]
 html_favicon = "images/robocop.ico"

--- a/docs/source/disablers.rst
+++ b/docs/source/disablers.rst
@@ -1,0 +1,114 @@
+.. _disablers:
+
+*********
+Disablers
+*********
+
+Rules can be disabled directly from Robot Framework code.
+A special comment needs to be placed in order to disable specific rules of Robocop.
+The comments is always prefixed with ``robocop`` marker followed by ``off`` or ``on`` word keywords::
+
+    # robocop: off
+
+The keyword may optionally have specified rules, separated by comma::
+
+    # robocop: off=rule1,rule2
+
+The disablers are also context-aware, meaning that they turn off the Robocop rules for the related code block,
+e.g. keyword, test case, or even for loops and if statements.
+
+.. note::
+
+    The disablers are similar to how ``# noqa`` comment works for most linters.
+
+Disabling lines
+---------------
+
+It is possible to disable rule for particular line or lines::
+
+    Some Keyword  # robocop: off=rule1,rule2
+
+In this example no message will be printed for this line for rules named ``rule1``, ``rule2``.
+
+You can disable all rules with::
+
+    Some Keyword  # robocop: off
+
+Enabling back
+-------------
+
+Ignore whole blocks of code by defining a disabler in the new line::
+
+    # robocop: off=rule1
+
+All matched rules will be disabled until ``on`` command::
+
+    # robocop: on=rule1
+
+or::
+
+    # robocop: on
+
+.. note::
+
+    Previously, Robocop used ``enable`` and ``disable`` as disabler keywords. It is still supported, however ``on`` and
+    ``off`` are recommended instead.
+
+Disabling code blocks
+---------------------
+
+Ignored blocks can partly overlap. Rule name and rule id can be used interchangeably.
+
+The disabler is aware of the context where it was called, and it will be enabled again at the end of the current code
+block (such as keyword, test case, "for" and "while" loops and "if" statement). In the following example,
+``wrong-case-in-keyword-name`` disabler will disable the rule only inside the "for" loop.
+
+..  code-block:: robotframework
+    :caption: example.robot
+
+    *** Keywords ***
+    Compare Table With CSV Files
+        [Arguments]    ${table}    @{files}
+        ${data}    Get Data From Table    ${table}
+        FOR    ${file}    IN    @{files}
+            # robocop: off=wrong-case-in-keyword-name
+            Table data should be in file     ${data}    ${file}
+        END
+        Should Be Equal    ${erorrs}    @{EMPTY}
+
+Disabling files
+---------------
+
+It is possible to ignore whole file if you put Robocop disabler in the first comment section, at the beginning of the
+file.
+
+..  code-block:: robotframework
+    :caption: example.robot
+
+    # robocop: off=missing-doc-test-case
+
+    *** Test Cases ***
+    Some Test
+        Keyword 1
+        Keyword 2
+        Keyword 3
+
+    *** Keywords ***
+    Keyword 1
+        # robocop: off
+        Log  1
+
+    Keyword 2
+        Log  2
+
+    # robocop: off
+    Keyword 3
+        Log  3
+
+    Keyword 4
+        Log  4
+    # robocop: on
+
+In this example we are disabling ``missing-doc-test-case`` rule in the whole file.
+Also we are disabling all rules inside ``Keyword 1`` keyword and all lines between
+``Keyword 3`` and ``Keyword 4`` keywords.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,10 +6,17 @@ Robocop documentation
     :maxdepth: 2
     :caption: Contents:
 
-.. include:: overview.rst
+.. include:: overview/overview.rst
 
 Table of contents
 =================
+
+.. toctree::
+    :caption: Overview
+
+    Overview <self>
+    Linter <overview/linter>
+    Formatter <overview/formatter.rst>
 
 .. toctree::
     :maxdepth: 2
@@ -24,6 +31,7 @@ Table of contents
     :caption: Other features
 
     reports
+    disablers
 
 Index
 ==================

--- a/docs/source/overview/formatter.rst
+++ b/docs/source/overview/formatter.rst
@@ -1,0 +1,226 @@
+.. _formatter:
+
+*********
+Formatter
+*********
+
+Format your Robot Framework code by running:
+
+..  code-block:: none
+
+    robocop format
+
+It will recursively discover all ``*.robot`` and ``*.resource`` files in the current directory.
+
+You can also use path specific path or paths:
+
+..  code-block:: none
+
+    robocop format file.robot resources/etc test.robot
+
+Robocop will also find and skip paths from `.gitignore` files. It is possible to configure how Robocop discover
+files using various options - see X # TODO.
+
+Displaying the difference
+--------------------------
+If you want to see which lines are changed by tool add ``--diff`` flag:
+
+..  code-block:: none
+
+    robocop format --diff test.robot
+    --- test.robot before
+    +++ test.robot after
+    @@ -1,23 +1,15 @@
+     *** Test Cases ***
+    Simple IF
+    -    IF    $condition1
+    -        Keyword    argument
+    -    END
+    -    IF    $condition2
+    -        RETURN
+    -    END
+    +    IF    $condition1    Keyword    argument
+    +    IF    $condition2    RETURN
+
+File write mode
+---------------
+Pass ``--no-overwrite`` flag to not modify the files when running the `Robocop`. Combine it with ``--diff`` to run a preview
+of how files will look after formatting:
+
+..  code-block:: none
+
+    robocop format --no-overwrite test.robot
+
+Status code
+------------
+By default `Robocop` returns 0 exit code after successful run and 1 if there was an error. You can make `Robocop` exit 1
+if any file would be transformed by passing ``--check``. By default files will not be transformed (same as running with
+``--no-overwrite``):
+
+..  code-block:: none
+
+    robocop format --check golden.robot
+    0
+    robocop format --check ugly.robot
+    1
+
+If you want `Robocop` to transform the files while using ``--check`` flag add ``--overwrite``:
+
+..  code-block:: none
+
+    robocop format --check --overwrite file.robot
+
+Configuration
+--------------
+See :ref:`configuration` for information how to configure `Robocop`.
+
+List of formatters
+-------------------
+
+# TODO
+
+To see list of formatters included with `Robocop` use ``list formatters``::
+
+    > robotidy list formatters
+                  Transformers
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+    ┃ Name                       ┃ Enabled ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+    │ AddMissingEnd              │ Yes     │
+    │ NormalizeSeparators        │ Yes     │
+    │ DiscardEmptySections       │ Yes     │
+    │ MergeAndOrderSections      │ Yes     │
+    │ RemoveEmptySettings        │ Yes     │
+    │ NormalizeAssignments       │ Yes     │
+    │ OrderSettings              │ Yes     │
+    │ OrderSettingsSection       │ Yes     │
+    │ NormalizeTags              │ Yes     │
+    │ OrderTags                  │ No      │
+    │ IndentNestedKeywords       │ No      │
+    │ AlignSettingsSection       │ Yes     │
+    │ AlignVariablesSection      │ Yes     │
+    │ AlignTemplatedTestCases    │ No      │
+    │ AlignTestCasesSection      │ No      │
+    │ AlignKeywordsSection       │ No      │
+    │ NormalizeNewLines          │ Yes     │
+    │ NormalizeSectionHeaderName │ Yes     │
+    │ NormalizeSettingName       │ Yes     │
+    │ ReplaceRunKeywordIf        │ Yes     │
+    │ SplitTooLongLine           │ Yes     │
+    │ SmartSortKeywords          │ No      │
+    │ RenameTestCases            │ No      │
+    │ RenameKeywords             │ No      │
+    │ ReplaceReturns             │ Yes     │
+    │ ReplaceBreakContinue       │ Yes     │
+    │ InlineIf                   │ Yes     │
+    │ Translate                  │ No      │
+    └────────────────────────────┴─────────┘
+
+    Formatters are listed in the order they are run by default. The status of the formatter will be displayed in the
+    different color if it is changed by the configuration.
+    To see detailed docs run:
+        robotidy --desc transformer_name
+    or
+        robotidy --desc all
+
+    Non-default formatters needs to be selected explicitly with --select or configured with param `enabled=True`.
+
+Pass optional value ``enabled`` or ``disabled`` to filter out output by the status of the formatter::
+
+    > robocop list formatters --filter disabled
+                    Transformers
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+    ┃ Name                    ┃ Enabled ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+    │ OrderTags               │ No      │
+    │ IndentNestedKeywords    │ No      │
+    │ AlignTemplatedTestCases │ No      │
+    │ AlignTestCasesSection   │ No      │
+    │ AlignKeywordsSection    │ No      │
+    │ SmartSortKeywords       │ No      │
+    │ RenameTestCases         │ No      │
+    │ RenameKeywords          │ No      │
+    │ Translate               │ No      │
+    └─────────────────────────┴─────────┘
+    (...)
+
+The configuration is reflected in the output. For example combining ``--select`` (which only runs selected
+formatters) and ``enabled`` gives us::
+
+    > robocop list formatters --filter enabled --select DiscardEmptySections
+               Transformers
+    ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+    ┃ Name                 ┃ Enabled ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+    │ DiscardEmptySections │ Yes     │
+    └──────────────────────┴─────────┘
+    (...)
+
+# TODO: replacement
+You can display short documentation on particular transformer with ``--desc``::
+
+    > robotidy --desc DiscardEmptySections
+    Transformer DiscardEmptySections:
+
+        Remove empty sections.
+        Sections are considered empty if there are only empty lines inside.
+        You can remove sections with only comments by setting 'allow_only_comments' parameter to False:
+
+            *** Variables ***
+            # this section will be removed with'alow_only_comments' parameter set to False
+
+        Supports global formatting params: '--startline' and '--endline'.
+
+        See https://robotidy.readthedocs.io/en/latest/transformers/DiscardEmptySections.html for more examples.
+
+Format selected lines
+---------------------
+Most formatters support running `Robocop` only on selected lines. Use ``--startline`` and ``--endline`` for this::
+
+    robocop format --startline 5 --endline 10 file.robot
+
+If you want to disable formatting in particular files see disablers section in :ref:`configuration`.
+
+Format code from standard input
+--------------------------------
+Use ``-`` to load code from input:
+
+..  code-block:: none
+
+    cat file.robot | robocop format -
+
+Line endings
+----------------
+
+When working on multiple platforms the file can contain different line endings (``CRLF``, ``LF``). By default
+Robocop will replace all line endings with system native line ending. It may be problematic if you're using
+different platforms. You can force specific line ending or autodetect line ending used in the file and use it by
+configuring ``lineseparator`` option:
+
+- native:  use operating system's native line endings (default)
+- windows: use Windows line endings (CRLF)
+- unix:    use Unix line endings (LF)
+- auto:    maintain existing line endings (uses what's used in the first line of the file)
+
+Rerun the formatting in place
+------------------------------
+
+Because of high independence of each formatter, Robocop runs them in specific order to obtain predictable results.
+But sometimes the subsequent formatter modifies the file to the point that it requires another run of Robocop.
+Good example would be one formatter that replaces the deprecated syntax - but new syntax is inserted using standard
+whitespace. If there is transformer that aligns this whitespace according to special rules
+(like ``AlignKeywordsSection``) we need to run Robocop again to format this whitespace.
+
+This could be inconvenient in some cases where user had to rerun Robocop without knowing why. That's why Robocop
+now has option ``reruns`` that allows to define limit of how many extra reruns Robocop can perform if the
+file keeps changing after the transformation. The default is ``0``. Recommended value is ``3``
+although in vast majority of cases one extra run should suffice (and only in cases described above).
+
+Example usage:
+
+..  code-block:: none
+
+    > robocop format --reruns 3 --diff test.robot
+
+Note that if you enable it, it can double the execution time of Robocop (if the file was modified, it will be
+formatted again to check if next formatting does not further modify the file).

--- a/docs/source/overview/linter.rst
+++ b/docs/source/overview/linter.rst
@@ -1,0 +1,164 @@
+.. _linter:
+
+*******
+Linter
+*******
+
+Lint your Robot Framework code by running::
+
+    robocop check
+
+It will recursively discover all ``*.robot`` and ``*.resource`` files in the current directory.
+
+You can also use path specific path or paths::
+
+    robocop check file.robot resources/etc test.robot
+
+Robocop will also find and skip paths from `.gitignore` files. It is possible to configure how Robocop discover
+files using various options - see X # TODO.
+
+An example of the output the tool can produce::
+
+    # TODO: Update output after extended is introduced
+    \Users\OCP\test.robot:7:1 [W] 0509 Section '*** Variables ***' is empty (empty-section)
+    \Users\OCP\test.robot:22:1 [E] 0801 Multiple test cases with name "Simple Test" (first occurrence in line 17) (duplicated-test-case)
+    \Users\OCP\test.robot:42:1 [E] 0810 Both Task(s) and Test Case(s) section headers defined in file (both-tests-and-tasks)
+    \Users\OCP\test.robot:48:1 [W] 0302 Keyword 'my keyword' does not follow case convention (wrong-case-in-keyword-name)
+    \Users\OCP\test.robot:51:13 [I] 0606 Tag 'mytag' is already set by Test Tags in suite settings (tag-already-set-in-test-tags)
+
+    Found 5 issues: 2 ERRORs, 2 WARNINGs, 1 INFO.
+
+Rules management
+================
+
+Select rules
+------------
+
+Rules can be selected or ignored using configuration.
+Use ``--select`` and ``--ignore`` to select only rules to run or run all default rules except ignored ones:
+
+.. tab-set::
+
+    .. tab-item:: Cli
+
+        .. code:: none
+
+             robocop check --select rule1 --select rule2 --select rule3 --ignore rule2
+
+    .. tab-item:: Configuration file
+
+        .. code:: toml
+
+            [robocop.linter]
+            select = [
+                "rule1",
+                "rule2",
+                "rule3"
+            ]
+            ignore = [
+                "rule2"
+            ]
+
+In this example we are selecting ``rule1``, ``rule2`` and ``rule3``. Additionally ``rule2`` is ignored so Robocop
+will only report ``rule1`` and ``rule3``.
+
+More in :ref:`including-rules`.
+
+Disabling rules from source code
+--------------------------------
+
+It is also possible to disable rule(s) from Robot Framework source code.
+Use ``# robocop: disable`` and optionally a rule that is going to be disabled, e.g.::
+
+    *** Keywords ***
+    Display Sentence
+        [Arguments]      ${sentence}
+        ${one-liner}     Parse Sentence  ${sentence}  # robocop: disable=hyphen-in-variable-name
+        Print To Welcome Page   ${one-liner}
+
+Learn more about disablers here - :ref:`disablers`.
+
+List rules
+----------
+
+To see the list of all the rules, run::
+
+    robocop list rules
+
+You can provide a ``--pattern`` to filter the rules that you are interested in, e.g.
+``robocop list rules --pattern *doc*``.
+
+Read more about how to list the rules in :ref:`list-rules`.
+
+.. note::
+
+    All Robocop rules are also nicely available here at :ref:`rules list`.
+
+Handling output
+===============
+
+Format output message
+---------------------
+
+Format of rules output messages can be redefined. More in messages documentation: :ref:`output-message-format`.
+
+Save output to file
+-------------------
+
+# TODO
+You can redirect output of Robocop to a file by using pipes (``>`` in unix) or by ``-o`` / ``--output`` argument::
+
+  robocop --output robocop.log .
+
+Generating reports
+------------------
+
+You can generate reports after run. Available reports are described in :ref:`reports`.
+
+.. _return_status:
+
+Language support
+================
+
+Robot Framework 6.0 added support for Robot settings and headers translation. Robocop will not recognize translated names unless
+it is properly configured. You can supply language code or name in the configuration using ``--language / -l`` option:
+
+.. tab-set::
+
+    .. tab-item:: Cli
+
+        .. code:: none
+
+             robocop check --language fi
+
+    .. tab-item:: Configuration file
+
+        .. code:: toml
+
+            [robocop.linter]
+            language = [
+                "fi"
+            ]
+
+Support multiple languages by either using ``language`` option multiple times:
+
+
+.. tab-set::
+
+    .. tab-item:: Cli
+
+        .. code:: none
+
+            robocop check -l pl -l pt
+
+    .. tab-item:: Configuration file
+
+        .. code:: toml
+
+            [robocop.linter]
+            language = [
+                "pl",
+                "pt"
+            ]
+
+Custom language file is currently not supported.

--- a/docs/source/overview/overview.rst
+++ b/docs/source/overview/overview.rst
@@ -27,8 +27,11 @@ You can install Robocop simply by running::
 Usage
 =====
 
-Robocop runs by default from the current directory and it discovers supported files recursively.
-You can simply run::
+Robocop discovers supported files from the current directory and its sub-directories.
+
+You can simply run:
+
+..  code-block:: none
 
     robocop check
     robocop format
@@ -37,26 +40,14 @@ All command line commands and options can be displayed in help message by execut
 
     robocop -h
 
-Example Output
-==============
+Refer to overview pages to read more (:ref:`linter`, :ref:`formatter`).
 
-Executing command::
+Shell autocompletion
+====================
 
-    robocop check --report rules_by_error_type test.robot
+It is possible use shell autocompletion by installing it for the current shell::
 
-Will result in following output:
-
-# TODO: update
-
-..  code-block:: none
-
-    \Users\OCP\test.robot:7:1 [W] 0509 Section '*** Variables ***' is empty (empty-section)
-    \Users\OCP\test.robot:22:1 [E] 0801 Multiple test cases with name "Simple Test" (first occurrence in line 17) (duplicated-test-case)
-    \Users\OCP\test.robot:42:1 [E] 0810 Both Task(s) and Test Case(s) section headers defined in file (both-tests-and-tasks)
-    \Users\OCP\test.robot:48:1 [W] 0302 Keyword 'my keyword' does not follow case convention (wrong-case-in-keyword-name)
-    \Users\OCP\test.robot:51:13 [I] 0606 Tag 'mytag' is already set by Test Tags in suite settings (tag-already-set-in-test-tags)
-
-    Found 5 issues: 2 ERRORs, 2 WARNINGs, 1 INFO.
+    robocop --install-completion
 
 Values
 ======

--- a/docs/source/rule_basics.rst
+++ b/docs/source/rule_basics.rst
@@ -11,10 +11,10 @@ Checkers
 
 .. automodule:: robocop.linter.rules
 
-.. _listing-rules:
+.. _list-rules:
 
-Listing available rules
------------------------
+List available rules
+--------------------
 
 To get list of available rules (with enabled/disabled status) use ``list rules`` command:
 

--- a/src/robocop/formatter/runner.py
+++ b/src/robocop/formatter/runner.py
@@ -92,7 +92,7 @@ class RobocopFormatter:
             )
         if not self.config_manager.default_config.formatter.check or not changed_files:
             return 0
-        return 1
+        return 1  # FIXME: ensure proper exit status is returned
 
     def format_until_stable(self, model: File, disabler_finder: disablers.RegisterDisablers):
         diff, old_model, new_model = self.format(model, disabler_finder.disablers)


### PR DESCRIPTION
Added more documentation (partly copied from existing linter & formatter, but with heavier refactors).

I'm starting to merge the documentation for both tools so it does make sense. For example overview section splits into linter & formatter subsections:

![image](https://github.com/user-attachments/assets/ce72c7aa-8ac2-4c19-8a54-3b2944cc2eb0)
